### PR TITLE
Changed the pipeline script example

### DIFF
--- a/admin_guide/continuous_integration/jenkins_pipeline_project.adoc
+++ b/admin_guide/continuous_integration/jenkins_pipeline_project.adoc
@@ -15,7 +15,7 @@ For example, a pipeline script that scans a serverless function and publishes th
 ----
 node('master') {
   stage('Scan') {
-    prismaCloudScanImage
+    prismaCloudScanFunction
   }
 
   stage('Publish') {
@@ -88,29 +88,35 @@ The following example script builds a simple image, and runs the scan and publis
 +
 [source]
 ----
-node {
-   stage('Build') {
-      // Build an image for scanning
-      sh 'echo "FROM imiell/bad-dockerfile:latest" > Dockerfile'
-      sh 'docker build --no-cache -t test/test-image:0.1 .'
-   }
+pipeline {
+  agent any
+       stages {
+          stage('Build') {
+            // Build an image for scanning
+            sh 'echo "FROM imiell/bad-dockerfile:latest" > Dockerfile'
+            sh 'docker build --no-cache -t test/test-image:0.1 .'
+          }
 
-   stage('Scan') {
-      prismaCloudScanImage ca: '',
-        cert: '',
-        dockerAddress: 'unix:///var/run/docker.sock',
-        image: 'test/test-image*',
-        key: '',
-        logLevel: 'info',
-        podmanPath: '',
-        project: '',
-        resultsFile: 'prisma-cloud-scan-results.json',
-        ignoreImageBuildTime:true
-   }
+          stage('Scan') {
+            // Scan the image
+            prismaCloudScanImage ca: '',
+            cert: '',
+            dockerAddress: 'unix:///var/run/docker.sock',
+            image: 'test/test-image*',
+            key: '',
+            logLevel: 'info',
+            podmanPath: '',
+            project: '',
+            resultsFile: 'prisma-cloud-scan-results.json',
+            ignoreImageBuildTime:true
+          }
+       }
 
-   stage('Publish') {
-      prismaCloudPublish resultsFilePattern: 'prisma-cloud-scan-results.json'
-  }
+       post { // The post section lets you run the publish step regardless of the scan results
+            always {
+                prismaCloudPublish resultsFilePattern: 'prisma-cloud-scan-results.json'
+            }
+       }
 }
 ----
 


### PR DESCRIPTION
Updated the pipeline script example with the "post" section, which lets the user run the publish step regardless of the scan results (fail/pass). In the previous example, the publish step run only when the scan passed.