### PR TITLE
Updated the container image download

### DIFF
--- a/admin_guide/install/twistlock_container_images.adoc
+++ b/admin_guide/install/twistlock_container_images.adoc
@@ -27,7 +27,7 @@ endif::compute_edition[]
 [.task]
 === Retrieving Prisma Cloud images using basic auth
 
-Authenticate using _docker login_, then retrieve the Prisma Cloud images using _docker pull_.
+Authenticate using _docker login_ or _podman login_, then retrieve the Prisma Cloud images using _docker pull_ or _podman pull_.
 For basic authorization, the registry is accessible at _registry.twistlock.com_.
 
 [IMPORTANT]
@@ -47,7 +47,7 @@ registry.twistlock.com/twistlock/defender:defender_19_07_363.
 [.procedure]
 . Authenticate with the registry.
 +
-  $ docker login registry.twistlock.com
+  $ docker (or podman) login registry.twistlock.com
   Username:
   Password:
 +
@@ -56,13 +56,13 @@ Where *Username* can be any string, and *Password* must be your access token.
 ifdef::compute_edition[]
 . Pull the Console image from the Prisma Cloud registry.
 
-  $ docker pull registry.twistlock.com/twistlock/console:console_<VERSION>
+  $ docker (or podman) pull registry.twistlock.com/twistlock/console:console_<VERSION>
 
 endif::compute_edition[]
 
 . Pull the Defender image from the Prisma Cloud registry.
 
-  $ docker pull registry.twistlock.com/twistlock/defender:defender_<VERSION>
+  $ docker (or podman) pull registry.twistlock.com/twistlock/defender:defender_<VERSION>
 
 
 [.task]
@@ -71,8 +71,8 @@ endif::compute_edition[]
 Retrieve Prisma Cloud images with a single command by embedding your access token into the registry URL.
 For URL authorization, the registry is accessible at _registry-auth.twistlock.com_.
 
-By embedding your access token into the registry URL, you only need to run _docker pull_.
-The _docker login_ command isn't required.
+By embedding your access token into the registry URL, you only need to run _docker pull_ or _podman pull_.
+The _docker login_ or _podman login_ command isn't required.
 
 The format for the registry URL is: `registry-auth.twistlock.com/tw_<ACCESS-TOKEN>/<IMAGE>:<TAG>`
 
@@ -89,7 +89,7 @@ registry.twistlock.com/twistlock/defender:defender_19_07_363.
 *Prerequisites:*
 
 * You have a Prisma Cloud access token.
-* The Docker client requires that repository names be lowercase.
+* The Docker or Podman client requires that repository names be lowercase.
 Therefore, all characters in your access token must be lowercase.
 To convert your access token to lowercase characters, use the following command:
 +
@@ -99,12 +99,12 @@ To convert your access token to lowercase characters, use the following command:
 ifdef::compute_edition[]
 . Pull the Console image from the Prisma Cloud registry.
 
-  $ docker pull \
+  $ docker (or podman) pull \
     registry-auth.twistlock.com/tw_<ACCESS-TOKEN>/twistlock/console:console_<VERION>
 
 endif::compute_edition[]
 
 . Pull the Defender image from the Prisma Cloud registry.
 
-  $ docker pull \
+  $ docker (or podman) pull \
     registry-auth.twistlock.com/tw_<ACCESS-TOKEN>/twistlock/defender:defender_<VERSION>


### PR DESCRIPTION
Now it is also showing that you can use podman with the same commands. Openshift 4 doesn't have docker daemon, so we need to show that you can also use podman. I did that with a OpenShift 4 customer and both methods worked with Podman as well.