### PR TITLE
updating from Manage/System/Logging to Alerts/Logging

### DIFF
--- a/admin_guide/audit/logging.adoc
+++ b/admin_guide/audit/logging.adoc
@@ -3,7 +3,7 @@
 You can configure Prisma Cloud to send audit event records (audits) to syslog and/or stdout.
 
 Syslog integration must be turned on manually.
-Open Console, go to *Manage > System > Logging*, then set *Syslog* to *Enabled*.
+Open Console, go to *Alerts > Logging*, then set *Syslog* to *Enabled*.
 Prisma Cloud connects to the syslog socket on _/dev/log_.
 Stdout integration can be enabled from the same tab.
 
@@ -81,7 +81,7 @@ The custom string serves as a marker that lets you correlate specific events to 
 [.procedure]
 . Open Console.
 
-. Go to *Manage > System > Logging > Syslog*.
+. Go to *Alerts > Logging > Syslog*.
 
 . Set *Syslog* to *Enabled*.
 
@@ -156,7 +156,7 @@ Example host scan:
 Records a compliance finding.
 These messages are tagged with __log_type="compliance"__, and are generated as a byproduct of container scans, image scans, host scans, and registry scans.
 
-Compliance issues are only recorded when *Detailed output for vulnerabilities and compliance* is enabled in *Manage > System > Syslog*.
+Compliance issues are only recorded when *Detailed output for vulnerabilities and compliance* is enabled in *Alerts > Syslog*.
 
 A syslog entry is generated for each compliance issue.
 This can result in a significant amount of data, which is why verbose output is disabled by default.
@@ -214,7 +214,7 @@ Example host compliance issue:
 Records a vulnerability finding.
 These messages are tagged with __log_type="vulnerability"__, and are generated as a byproduct of image scans, host scans, and registry scans.
 
-Vulnerability issues are only recorded when *Detailed output for vulnerabilities and compliance* is enabled in *Manage > System > Syslog*.
+Vulnerability issues are only recorded when *Detailed output for vulnerabilities and compliance* is enabled in *Alerts > Syslog*.
 
 A syslog entry is generated for each vulnerability for each package.
 This can result in a significant amount of data, which is why verbose output is disabled by default.
@@ -437,7 +437,7 @@ Example:
 
 Records all processes spawned in a container.
 
-Process audits are only recorded when *Detailed output of all runtime process activity* is enabled in Manage > System > Syslog.
+Process audits are only recorded when *Detailed output of all runtime process activity* is enabled in Alerts > Syslog.
 
 Note that process activity that breaches your runtime policy is separately audited.
 For more infomration, see the container runtime audit section.


### PR DESCRIPTION
In 20.04 we moved the Logging page from Manage/System/Logging to Alerts/Logging.  This pull request is to update the page.