### PR TITLE
Fixed existing PCF integration procedure

### DIFF
--- a/admin_guide/vulnerability_management/pcf_blobstore.adoc
+++ b/admin_guide/vulnerability_management/pcf_blobstore.adoc
@@ -37,12 +37,11 @@ endif::compute_edition[]
 NOTE: External blobstores that require a custom authentication flow, such as those offered by cloud providers, are not supported.
 
 [.procedure]
-. https://docs.twistlock.com/docs/latest/download/releases.html[Download] the latest Prisma Cloud release to your local host.
+. Go to *Manage > System > Downloads*. Download the PCF tile.
 
 . In the Ops Manager Installation Dashboard, click *Import a Product*.
 
-. Select the tile from the Prisma Cloud release directory.
-It can be found in TWISTLOCK-RELEASE/pivotal/twistlock-tile-VERSION.pivotal.
+. Select the tile you've downloaded.
 
 . Retrieve the install command from Prisma Cloud Console.
 It will be used to configure the tile.

--- a/admin_guide/vulnerability_management/pcf_blobstore.adoc
+++ b/admin_guide/vulnerability_management/pcf_blobstore.adoc
@@ -37,16 +37,12 @@ endif::compute_edition[]
 NOTE: External blobstores that require a custom authentication flow, such as those offered by cloud providers, are not supported.
 
 [.procedure]
-. Go to *Manage > System > Downloads*. Download the PCF tile.
+. In Prisma Cloud Console, go to *Manage > System > Downloads*, and download the PCF tile.
 
-. In the Ops Manager Installation Dashboard, click *Import a Product*.
-
-. Select the tile you've downloaded.
+. In the Ops Manager Installation Dashboard, click *Import a Product*, and select the tile you downloaded.
 
 . Retrieve the install command from Prisma Cloud Console.
-It will be used to configure the tile.
-
-.. Log into Prisma Cloud Console.
+It's used to configure the tile.
 
 .. Go to *Manage > Defenders > Deploy*.
 
@@ -59,7 +55,7 @@ It will be used to configure the tile.
 
 .. Copy the install command and set it aside.
 
-. Navigate to the PCF Ops Manager Installation Dashboard.
+. Go to the PCF Ops Manager Installation Dashboard.
 
 . Add the Prisma Cloud tile to your staging area.
 Click the *+* button next to the version of the tile you want to install.


### PR DESCRIPTION
The tile should be now downloaded from the console and doesn't exist in the release package.