### PR TITLE
Added database encryption notes for SaaS

### DIFF
--- a/admin_guide/install/getting_started.adoc
+++ b/admin_guide/install/getting_started.adoc
@@ -160,3 +160,7 @@ ifdef::compute_edition[]
 The Prisma Cloud database is not encrypted at rest, however all credentials and otherwise secure information is encrypted with AES 256 bit encryption.
 If you require data at rest to be encrypted, then underlying persistence storage /var/lib/twistlock can be mounted with one of the many options that support this.
 endif::compute_edition[]
+
+ifdef::prisma_cloud[]
+The Prisma Cloud database is encrypted at rest with Google Cloud Storage with AES 256 bit encryption.   
+endif::prisma_cloud[]


### PR DESCRIPTION
ifdef::prisma_cloud[]
The Prisma Cloud database is encrypted at rest with Google Cloud Storage with AES 256 bit encryption.   
endif::prisma_cloud[]