### PR TITLE
Remove references to --ci flag

### DIFF
--- a/admin_guide/tools/twistcli_scan_images.adoc
+++ b/admin_guide/tools/twistcli_scan_images.adoc
@@ -104,9 +104,6 @@ Write the results of the scan to a file in JSON format.
 +
 Example: --output-file examplescan
 
-`--ci`::
-Evaluate the CI Policy and store results in the Console.
-
 `--details`::
 Show all vulnerability details.
 
@@ -171,8 +168,6 @@ If it fails, for whatever reason, you want to fail everything because there is a
 
 === Scan results
 
-Scan reports can viewed in Prisma Cloud Console, but only when you pass the `--ci` flag to `twistcli`.
-This flag is designed to minimize clutter in the Console UI, since many people might be using `twistcli` for scanning, but everyone will need to share it with the larger team in Console.
 To view scan reports in Console, go to *Monitor > Vulnerabilities > Images > CI* or *Monitor > Compliance > Images > CI*.
 
 You can also retrieve scan reports in JSON format using the Prisma Cloud API.
@@ -213,8 +208,6 @@ By default, twistcli writes scan results to stdout.
 To write scan results to stdout in tabular format, pass the `--details` flag to twistcli.
 
 To write scan results to a file in JSON format, pass the `--output-file` flag to twistcli.
-
-To publish scan results to Console, pass the `--ci` flag to twistcli.
 
 
 ==== API


### PR DESCRIPTION
Removed references to --ci flag per 20.04.169 release, which reverted the ci flag changes.