### PR TITLE
add sentence about installing on OpenShift 4+.

### DIFF
--- a/admin_guide/install/install_openshift.adoc
+++ b/admin_guide/install/install_openshift.adoc
@@ -533,6 +533,28 @@ NAME                    DESIRED   CURRENT  READY  UP-TO-DATE  AVAILABLE  NODE SE
 twistlock-defender-ds   4         4        4      4           4          Deploy_Prisma Cloud=true
 ----
 
+=== Deploy Defender also to master nodes in OpenShift 4+
+
+By default OpenShift 4+ prevents workload to be scheduled to master nodes using Taints. Because of this, Defender is by default only deployed to worker / compute nodes.
++
+[source]
+----
+...
+taints:
+- effect: NoSchedule
+  key: node-role.kubernetes.io/master
+...
+----
+
+Any workload that doesn't have matching Toleration, cannot be deployed to masters. Defender daemonset doesn't have that and thus not deployed to master nodes. Adding matching toleration to daemonset allows scheduling of Defender also to master nodes.
++
+[source]
+----
+oc patch daemonset twistlock-defender-ds --type=merge -p '{"spec":{"template":{"spec":{"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]}}}}'
+----
+
+
+
 
 === Install Prisma Cloud with Helm charts
 

--- a/admin_guide/install/install_openshift.adoc
+++ b/admin_guide/install/install_openshift.adoc
@@ -362,7 +362,7 @@ The _--cluster-address_ flag specifies the address Defender uses to connect to C
 For Defenders deployed inside the cluster, specify Prisma Cloud Console’s service name, twistlock-console or twistlock-console.twistlock.svc, or cluster IP address.
 For Defenders deployed outside the cluster, specify either Console’s external address, which is exposed by your external route.
 
-If SELinux is enabled on the OpenShift nodes, pass the _--selinux-enabled_ argument to twistcli.
+If SELinux is enabled on the OpenShift nodes, pass the _--selinux-enabled_ argument to twistcli. By default SELinux is enabled in OpenShift 4+ and runtime is always CRI-O. When installing on OpenShift 4+ add --selinux-enabled and --cri arguments.
 
 [.procedure]
 . Generate the Defender DaemonSet YAML.


### PR DESCRIPTION
OpenShift 4+ is using SELinux by default and runtime is CRI-o. Added sentence to about arguments for those.