### PR TITLE
Update install_serverless_defender_autoprotect.adoc

### DIFF
--- a/admin_guide/install/install_defender/install_serverless_defender_autoprotect.adoc
+++ b/admin_guide/install/install_defender/install_serverless_defender_autoprotect.adoc
@@ -34,6 +34,8 @@ Add the following policy to an IAM user or role:
         "lambda:PublishLayerVersion",
         "lambda:UpdateFunctionConfiguration",
         "lambda:GetLayerVersion",
+        "lambda:ListFunctions",
+        "lambda:GetFunction",
         "lambda:GetFunctionConfiguration",
         "iam:SimulatePrincipalPolicy"
       ],


### PR DESCRIPTION
Serverless autoprotect won't work without "lambda:ListFunctions" and "lambda:GetFunction",