### PR TITLE
Link to relevant Google Cloud marketplace item

### DIFF
--- a/admin_guide/alerts/google_cloud_scc.adoc
+++ b/admin_guide/alerts/google_cloud_scc.adoc
@@ -12,7 +12,7 @@ Prisma Cloud is a registered Google Cloud Platform Marketplace partner.
 In Google Cloud Platform (GCP), create a service account in your project that has the *Cloud Security Command Center API* enabled.
 You will need the service account keys, API, and Organization ID to enable this feature.
 
-You should have already enabled and onboarded Prisma Cloud as a Security Source in Google Security Command Center.
+You should have already enabled and onboarded https://console.cloud.google.com/marketplace/details/twistlock/twistlock[Prisma Cloud as a Security Source in Google Security Command Center].
 Prisma Cloud supports the alpha and beta versions of Google Security Command Center.
 The following instructions show how to configure the beta version.
 


### PR DESCRIPTION
Docs don't link to anything in the Google Cloud marketplace and currently there are both Prisma Cloud (still branded Redlock) and Twistlock integrations, which is confusing.