### PR TITLE
Hardware requirements for the Console

### DIFF
--- a/admin_guide/install/system_requirements.adoc
+++ b/admin_guide/install/system_requirements.adoc
@@ -10,8 +10,8 @@ Before installing Prisma Cloud, verify that your environment meets the minimum r
 
 ifdef::compute_edition[]
 * Console --
-** When fewer than 100 Defenders are connected, Console requires 1GB of RAM and 10GB of persistent storage.
-** When more than 100 Defenders are connected, Console requires 3GB of RAM and 50GB of persistent storage.
+** When 1000 Defenders are connected, Console requires 4v CPU, 8GB of RAM, and 100GB of persistent storage.
+** When 5000 Defenders are connected, Console requires 8v CPU, 30GB of RAM, and 1TB of persistent storage.
 endif::compute_edition[]
 
 * Defender --

--- a/admin_guide/install/system_requirements.adoc
+++ b/admin_guide/install/system_requirements.adoc
@@ -10,8 +10,8 @@ Before installing Prisma Cloud, verify that your environment meets the minimum r
 
 ifdef::compute_edition[]
 * Console --
-** When 1000 Defenders are connected, Console requires 4v CPU, 8GB of RAM, and 100GB of persistent storage.
-** When 5000 Defenders are connected, Console requires 8v CPU, 30GB of RAM, and 1TB of persistent storage.
+** When up to 1000 Defenders are connected, Console requires 4 vCPUs, 8GB of RAM, and 100GB of persistent storage.
+** When 1001 - 5000 Defenders are connected, Console requires 8 vCPUs, 30GB of RAM, and 1TB of persistent storage.
 endif::compute_edition[]
 
 * Defender --


### PR DESCRIPTION
Updated the system requirements doc with the hardware requirements for the Console.

Following a question from a customer on the hardware required for the Console's machine, I verified it with QA.
Updated the system requirements doc according to the QA team testing on 1000 defenders' environment, and a scaled environment (5000 defenders).
When Galileo tests will be done for 10K defenders, we may need to update this again.

