### PR TITLE
Update waas.adoc

### DIFF
--- a/admin_guide/firewalls/waas.adoc
+++ b/admin_guide/firewalls/waas.adoc
@@ -22,7 +22,7 @@ Highlights of WAAS’s capabilities:
 === Architecture
 
 WAAS is deployed via Prisma Compute Defenders which operate as a transparent HTTP proxy, evaluating client requests against security policies before relaying the requests to your application.
-Defenders are deployed into the into the environment in which the web applications run.
+Defenders are deployed into the environment in which the web applications run.
 WAAS's management console is independent of the Defenders and can be self-hosted or provided as a service (SaaS):
 
 image::./CNAF-architecture.png[width=650]


### PR DESCRIPTION
Remove double "into the" from:
"Defenders are deployed into the into the environment in which the web applications run."