### PR TITLE
Status message for CSP downloads

### DIFF
--- a/admin_guide/welcome/releases.adoc
+++ b/admin_guide/welcome/releases.adoc
@@ -14,6 +14,10 @@ image::update_bell.png[width=800]
 
 Download the software from the Palo Alto Networks https://support.paloaltonetworks.com/[Customer Support portal].
 
+IMPORTANT: If you don't see *Prisma Cloud Compute Edition* in the drop-down list, contact customer support.
+They'll send you a direct link to the download.
+We are currently working on fixing all accounts that have this issue.
+
 [.procedure]
 . Log into the https://support.paloaltonetworks.com/[Customer Support portal].
 
@@ -30,6 +34,10 @@ image::releases_csp.png[width=800]
 
 Besides hosting the download on the Customer Support Portal, we also support programmatic download (e.g., curl, wget) of the release directly from our CDN.
 The link to the tarball is published in the release notes.
+
+IMPORTANT: If you don't see *Prisma Cloud Compute Edition* in the drop-down list, contact customer support.
+They'll send you a direct link to the download.
+We are currently working on fixing all accounts that have this issue.
 
 [.procedure]
 . Log into the https://support.paloaltonetworks.com/[Customer Support portal].

--- a/rn/release-information/download.adoc
+++ b/rn/release-information/download.adoc
@@ -14,6 +14,10 @@ image::update_bell.png[width=800]
 
 Download the software from the Palo Alto Networks https://support.paloaltonetworks.com/[Customer Support portal].
 
+IMPORTANT: If you don't see *Prisma Cloud Compute Edition* in the drop-down list, contact customer support.
+They'll send you a direct link to the download.
+We are currently working on fixing all accounts that have this issue.
+
 [.procedure]
 . Log into the https://support.paloaltonetworks.com/[Customer Support portal].
 
@@ -30,6 +34,10 @@ image::releases_csp.png[width=800]
 
 Besides hosting the download on the Customer Support Portal, we also support programmatic download (e.g., curl, wget) of the release directly from our CDN.
 The link to the tarball is published in the release notes.
+
+IMPORTANT: If you don't see *Prisma Cloud Compute Edition* in the drop-down list, contact customer support.
+They'll send you a direct link to the download.
+We are currently working on fixing all accounts that have this issue.
 
 [.procedure]
 . Log into the https://support.paloaltonetworks.com/[Customer Support portal].


### PR DESCRIPTION
The CSP team is fixing perm issues for customer accounts that can't see the Prisma Cloud Compute Edition downloads. Let customers know they should contact support directly if they have an issue.