### PR TITLE
Update collection limitations for Containers Audits

### DIFF
--- a/admin_guide/configure/collections.adoc
+++ b/admin_guide/configure/collections.adoc
@@ -221,7 +221,7 @@ Monitor/Compliance
 
 |Monitor/Events
 |Container audits
-|Images, Containers, Namespaces, Container Deployment Labels (under Labels), Cloud Account IDs
+|Images, Namespaces, Container Deployment Labels (under Labels), Cloud Account IDs
 
 |Monitor/Events
 |Host audits


### PR DESCRIPTION
Correction of the supported resources for using collections on Container Audits (Container resource is not supported, since the collections are set based on the container model only)