### PR TITLE
Fix rendering problem

### DIFF
--- a/admin_guide/api/automate_defender_install.adoc
+++ b/admin_guide/api/automate_defender_install.adoc
@@ -68,7 +68,7 @@ Use the token you just retrieved to get a list of deployed Defenders.
 . Download and run the Defender install script.
 
   $ curl \
-    -H "authorization: Bearer <TOKEN> \
+    -H "authorization: Bearer <TOKEN>" \
     -X POST \
     https://<COMPUTE_CONSOLE>:8083/api/v1/scripts/defender.sh \
     -o defender.sh && \
@@ -109,7 +109,7 @@ By default, it is 8084.
 . Download and run the Defender install script with the `--install-host` option.
 
   $ curl \
-    -H "authorization: Bearer <TOKEN> \
+    -H "authorization: Bearer <TOKEN>" \
     -X POST \
     https://<COMPUTE_CONSOLE>:8083/api/v1/scripts/defender.sh \
     -o defender.sh && \


### PR DESCRIPTION
Unbalanced quotations were causing the DITA XML to strip the `-X POST` param from the example curl commands.