### PR TITLE
Update collections.adoc

### DIFF
--- a/admin_guide/configure/collections.adoc
+++ b/admin_guide/configure/collections.adoc
@@ -280,7 +280,8 @@ Monitor/Compliance
 
 |Monitor/Events
 |Container audits 
-|Images, Namespaces, Clusters, Container Deployment Labels (under Labels), Cloud Account IDs. (Cluster Collections are not currently able to filter some events such as container audits, specifically.)
+|Images, Namespaces, Clusters, Container Deployment Labels (under Labels), Cloud Account IDs.
+(Cluster collections are not currently able to filter some events such as container audits, specifically.)
 
 |Monitor/Events
 |CNNF for Containers

--- a/admin_guide/configure/collections.adoc
+++ b/admin_guide/configure/collections.adoc
@@ -279,8 +279,8 @@ Monitor/Compliance
 |Images, Hosts, Namespaces, Clusters, Labels, Cloud Account IDs
 
 |Monitor/Events
-|Container audits
-|Images, Namespaces, Clusters, Container Deployment Labels (under Labels), Cloud Account IDs
+|Container audits 
+|Images, Namespaces, Clusters, Container Deployment Labels (under Labels), Cloud Account IDs. (Cluster Collections are not currently able to filter some events such as container audits, specifically.)
 
 |Monitor/Events
 |CNNF for Containers
@@ -401,5 +401,5 @@ After collections are created or updated, there are some views that are affected
 These views include historical records that keep their collections from creation time:
 
 * Images and Functions CI results view 
-* Events views
+* Events views 
 * Incidents view


### PR DESCRIPTION
Customer asked to include Cluster Collections in the docs as not an option to filter container audits.

|Monitor/Events
|Container audits 
|Images, Namespaces, Clusters, Container Deployment Labels (under Labels), Cloud Account IDs. (Cluster Collections are not currently able to filter some events such as container audits, specifically.)