### PR TITLE
Fix #306: Suppress /api/v1/registry/progress.

### DIFF
--- a/api/_build/suppress.cfg
+++ b/api/_build/suppress.cfg
@@ -50,3 +50,8 @@
 
 # microsegmentation
 /api/v1/microsegmentation
+
+# This endpoint has been deprecated since 19.07.
+# There is an open issue in engr's repo to clean up (see #26174).
+# In the meantime, suppress it in the doc gen process.
+/api/v1/registry/progress


### PR DESCRIPTION
It's been deprecated since 19.07.