### PR TITLE
Invalid character in example

### DIFF
--- a/admin_guide/authentication/credentials_store.adoc
+++ b/admin_guide/authentication/credentials_store.adoc
@@ -397,7 +397,7 @@ To get a service key:
 . Create a service principal and configure its access to Azure resources.
 
   $ az ad sp create-for-rbac \
-    --name <user>.twistlock-azure-cloud-discovery-<contributor|reader> \
+    --name <user>-twistlock-azure-cloud-discovery-<contributor|reader> \
     --role <reader|contributor> \
     --sdk-auth
 +


### PR DESCRIPTION
It appears that `.` isn't valid in the az command but `-` is