### PR TITLE
Update install_serverless_defender.adoc

### DIFF
--- a/admin_guide/install/install_defender/install_serverless_defender.adoc
+++ b/admin_guide/install/install_defender/install_serverless_defender.adoc
@@ -67,7 +67,7 @@ In your function code, import the Serverless Defender library and create a new p
 The protected handler will be called by AWS when your function is invoked.
 Update the project configuration file to add Prisma Cloud dependencies and package references.
 
-Prisma Cloud supports .NET Core 2.1.
+Prisma Cloud supports .NET Core 2.1 and 3.1.
 
 [.procedure]
 . Open Compute Console, and go to *Manage > Defenders > Deploy > Single Defender*.


### PR DESCRIPTION
Update .NET Core documentation to represent both 2.1 and 3.1 as stated in the Overview at the top of the page and on the system requirements page.