### PR TITLE
Add spell checker for the API docs.

### DIFF
--- a/api/_build/.spelling
+++ b/api/_build/.spelling
@@ -1,0 +1,69 @@
+# markdown-spellcheck spelling configuration file
+# Format - lines begining # are comments
+# global dictionary is at the start, file overrides afterwards
+# one word per line, to define a file override use ' - filename'
+# where filename is relative to this configuration file
+# Default - case sensitive
+AMIs
+appID
+Artifactory
+blobstore
+blobstores
+buildpack
+CoreOS
+CSV
+CVE
+CVEs
+CyberArk
+DaemonSet
+DaemonSets
+datastream
+datastreams
+Dockerfile
+executable
+executables
+Fargate
+hostname
+hostnames
+IPs
+JFrog
+Jira
+Kubernetes
+LoadBalancer
+macOS
+metadata
+namespace
+namespaces
+MongoDB
+Onebox
+OpenLDAP
+OpenSCAP
+OpenShift
+Prisma
+programmatically
+proxied
+Proxying
+rescan
+rescans
+runC
+runtime
+SaaS
+schemas
+serverless
+sha256
+signup
+Sonatype
+stdout
+subnet
+subnets
+sudo
+syslog
+Tanzu
+TAS
+twistcli
+twistlock
+Twistlock
+Ubuntu
+v2
+VMWare
+X.509

--- a/api/_build/spell-check.sh
+++ b/api/_build/spell-check.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Enable common error handling options.
+#set -o errexit
+set -o nounset
+set -o pipefail
+
+# https://stackoverflow.com/questions/592620/how-can-i-check-if-a-program-exists-from-a-bash-script
+if ! command -v mdspell &> /dev/null
+then
+    echo "mdspell could not be found"
+    exit
+fi
+
+# https://stackoverflow.com/questions/43707685/set-u-nounset-vs-checking-whether-i-have-arguments
+if (( $# >= 1 )); then
+  doc_dir="$1"
+else
+  doc_dir="../descriptions"
+fi
+
+# https://stackoverflow.com/questions/23356779/how-can-i-store-the-find-command-results-as-an-array-in-bash
+input='*.md'
+array=()
+while IFS=  read -r -d $'\0'; do
+  array+=("$REPLY")
+done < <(find "${doc_dir}" -name "${input}" -print0)
+
+count="${#array[*]}"
+if [[ count -eq 0 ]]; then
+  echo "No markdown files found"
+  exit 1
+else
+  echo "Files to spell check:"
+  echo "${#array[*]}"
+fi
+
+for i in "${array[@]}"; do
+   mdspell "-r" "-n" "-a" "--en-us" "${i}"
+done

--- a/api/descriptions/SCAP/id_delete.md
+++ b/api/descriptions/SCAP/id_delete.md
@@ -1,4 +1,4 @@
-This endpoint will delete any SCAP datastreams uploaded to the console. You can find `xml_name` from the /scap `GET` endpoint.
+This endpoint will delete any SCAP datastreams uploaded to the console. You can find `xml_name` from the `GET /api/v1/scap` endpoint.
 
 The following is an example curl command that uses basic auth to delete an uploaded datastreams configured for SCAP scanning:
 

--- a/api/descriptions/alert-profiles/id_delete.md
+++ b/api/descriptions/alert-profiles/id_delete.md
@@ -2,13 +2,13 @@ Deletes an alert profile entry by name.
 In the request payload, specify the alert profile name. 
 This method has no response data.
 
-The following example curl command uses basic auth to delete an existing alert profile entry, where **aqsa** is an alert profile name which is being deleted.
+The following example curl command deletes an existing alert profile named `PROFILE-NAME`.
 
 ```bash
 $ curl -k \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X DELETE \
-  https://<CONSOLE>:8083/api/v1/alert-profiles/aqsa
+  https://<CONSOLE>:8083/api/v1/alert-profiles/<PROFILE-NAME>
 ```
 

--- a/api/descriptions/audits/firewall_app_container_download_get.md
+++ b/api/descriptions/audits/firewall_app_container_download_get.md
@@ -11,4 +11,4 @@ $ curl -k \
   -X GET \
   -o cnaf-container-audits.csv \
   https://console:8083/api/v1/audits/firewall/app/container/download
-
+```

--- a/api/descriptions/audits/incidents_acknowledge_id_patch.md
+++ b/api/descriptions/audits/incidents_acknowledge_id_patch.md
@@ -1,6 +1,6 @@
 Use this call to acknowledge an incident and move it to Archived state. 
 Incident ID of the incident you want to archive is required.
-You can get incident ID from the list of incidents in GET /api/v1/audits/incidents. 
+You can get incident ID from the list of incidents in `GET /api/v1/audits/incidents`.
 
 Note that you can undo this action by changing "true" to "false" in the following example. 
 
@@ -12,5 +12,5 @@ $ curl -k \
    https://aqsa-console:8083/api/v1/audits/incidents/acknowledge/5c76e18784bf4b7278d9a820 -d '{"acknowledged":true}'
 ```
 
-Where 5c76e18784bf4b7278d9a820 is the incident ID
+Where `5c76e18784bf4b7278d9a820` is the incident ID
 

--- a/api/descriptions/audits/incidents_download_get.md
+++ b/api/descriptions/audits/incidents_download_get.md
@@ -1,8 +1,8 @@
 Twistlock analyzes individual audits and correlates them together to surface unfolding attacks.
 These chains of related audits are called incidents. 
-This api call retrieves a list of incidents that are not acknowledged (not in archived state).
+This endpoint retrieves a list of incidents that are not acknowledged (not in archived state).
 
-The following example uses basic auth to list incidents.
+The following example curl command lists all incidents.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/audits/incidents_filters_get.md
+++ b/api/descriptions/audits/incidents_filters_get.md
@@ -1,6 +1,6 @@
-This api call gives a list of incident categories found in your environment.
+This endpoint lists the incident categories found in your environment.
 
-The following example uses basic auth to list incident filters.
+The following example lists incident filters.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/audits/incidents_get.md
+++ b/api/descriptions/audits/incidents_get.md
@@ -1,8 +1,8 @@
 Twistlock analyzes individual audits and correlates them together to surface unfolding attacks.
 These chains of related audits are called incidents. 
-This api call retrieves a list of incidents that are not acknowledged (not in archived state).
+This endpoint retrieves a list of incidents that are not acknowledged (not in archived state).
 
-The following example uses basic auth to list incidents.
+The following example curl command lists all incidents.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/audits/kubernetes_download_get.md
+++ b/api/descriptions/audits/kubernetes_download_get.md
@@ -1,6 +1,6 @@
-Twistlock can provide events from kubernetes if this integration is configured.
+Twistlock can provide events from Kubernetes if this integration is configured.
 
-The following example uses basic auth to download all kubernetes events that are configured.
+The following example downloads all Kubernetes events that are configured.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/audits/kubernetes_get.md
+++ b/api/descriptions/audits/kubernetes_get.md
@@ -1,6 +1,6 @@
-Twistlock can provide events from kubernetes if this integration is configured.
+Twistlock can provide events from Kubernetes if this integration is configured.
 
-The following example uses basic auth to list all kubernetes events that are configured.
+The following example lists all Kubernetes events that are configured.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/audits/mgmt_filters_get.md
+++ b/api/descriptions/audits/mgmt_filters_get.md
@@ -1,7 +1,7 @@
 Retrieves a list of management audit types found in your environment. 
-These fields can be firther used as your queries to get management audit data.
+These fields can be further used as your queries to get management audit data.
 
-The following example curl command uses basic auth to retrieve all management audit filters
+The following example curl command retrieves all management audit filters
 
 ```bash
 $ curl -k \

--- a/api/descriptions/audits/runtime_container_download_get.md
+++ b/api/descriptions/audits/runtime_container_download_get.md
@@ -1,6 +1,4 @@
-Downloads the runtime container audit logs in csv format.
-
-A call to this api endpoint may resemble the following code snippet:
+Downloads the runtime container audit logs in CSV format.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/audits/runtime_container_get.md
+++ b/api/descriptions/audits/runtime_container_get.md
@@ -1,6 +1,5 @@
-Twistlock records an audit every time a runtime sensor (process, network, file system, and system call) detects activity that deviates from the predictive model. This endpoint retrieves all container audits from the console **Monitor > Runtime > Container Audits**.
-
-A call to this api endpoint may resemble the following code snippet:
+Twistlock records an audit every time a runtime sensor (process, network, file system, and system call) detects activity that deviates from the predictive model.
+This endpoint retrieves all container audits from the console **Monitor > Runtime > Container Audits**.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/audits/runtime_host_download_get.md
+++ b/api/descriptions/audits/runtime_host_download_get.md
@@ -1,6 +1,4 @@
-Downloads the runtime host audit logs in csv format.
-
-A call to this api endpoint may resemble the following code snippet:
+Downloads the runtime host audit logs in CSV format.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/audits/runtime_serverless_filters_get.md
+++ b/api/descriptions/audits/runtime_serverless_filters_get.md
@@ -1,6 +1,5 @@
-Returns all serverless filters in JSON format. These filters can be used in the base `GET` request as query parameters. 
-
-A call to this api endpoint may resemble the following code snippet:
+Returns all serverless filters in JSON format.
+These filters can be used in the base `GET` request as query parameters. 
 
 ```bash
 $ curl -k \

--- a/api/descriptions/authenticate-client/authenticate-client.md
+++ b/api/descriptions/authenticate-client/authenticate-client.md
@@ -1,5 +1,5 @@
 Retrieve an access token using a client certificate.
 Valid tokens are required to access the rest of the Twistlock API.
-Use this endpoint if your organization has rolled out multi-factor authentication built on x.509 certificates.
+Use this endpoint if your organization has rolled out multi-factor authentication built on X.509 certificates.
 
-The Twistlock API can also be accessed using [basic auth](https://docs.twistlock.com/docs/api/access_api.html).
+The API can also be accessed using [basic auth](https://docs.twistlock.com/docs/api/access_api.html).

--- a/api/descriptions/certs/server-certs_get.md
+++ b/api/descriptions/certs/server-certs_get.md
@@ -1,7 +1,5 @@
 Returns the server certificate bundle from the console.
 
-A call to this api endpoint may resemble the following code snippet:
-
 ```bash
 $ curl -k \
   -u <USER> \

--- a/api/descriptions/collections/name_put.md
+++ b/api/descriptions/collections/name_put.md
@@ -2,7 +2,7 @@ Updates the parameters that define a given collection.
 
 The following example curl command updates the parameters that define the collection named `finance_group_app`.
 In general, all parameters in your PUT request should be defined or redefined.
-Any field left unspecified is assigned the value of `""` (i.e. an emtpy string).
+Any field left unspecified is assigned the value of `""` (an empty string).
 
 ```bash
 $ curl -k \

--- a/api/descriptions/collections/post.md
+++ b/api/descriptions/collections/post.md
@@ -1,5 +1,5 @@
 Creates a new collection.
-Any field left unspecified is assigned the value of `""` (i.e. an emtpy string).
+Any field left unspecified is assigned the value of `""` (an empty string).
 
 ```bash
 $ curl -k \

--- a/api/descriptions/containers/count_get.md
+++ b/api/descriptions/containers/count_get.md
@@ -1,7 +1,5 @@
 Returns an integer representing the number of containers in your environment.
 
-A call to this api endpoint may resemble the following code snippet:
-
 ```bash
 $ curl -k \
   -u <USER> \

--- a/api/descriptions/containers/download_get.md
+++ b/api/descriptions/containers/download_get.md
@@ -1,7 +1,5 @@
 Downloads all container scan reports in CSV format.
 
-A call to this api endpoint may resemble the following code snippet:
-
 ```bash
 $ curl -k \
   -u <USER> \

--- a/api/descriptions/containers/filters_get.md
+++ b/api/descriptions/containers/filters_get.md
@@ -1,7 +1,5 @@
 Returns all container filters in JSON format. These filters can be used in the base `GET` request as query parameters. 
 
-A call to this api endpoint may resemble the following code snippet:
-
 ```bash
 $ curl -k \
   -u <USER> \

--- a/api/descriptions/containers/labels_get.md
+++ b/api/descriptions/containers/labels_get.md
@@ -1,7 +1,5 @@
 Returns an array of strings containing all of the labels.
 
-A call to this api endpoint may resemble the following code snippet:
-
 ```bash
 $ curl -k \
   -u <USER> \

--- a/api/descriptions/containers/names_get.md
+++ b/api/descriptions/containers/names_get.md
@@ -1,7 +1,5 @@
 Returns an array of strings containing all container names.
 
-A call to this api endpoint may resemble the following code snippet:
-
 ```bash
 $ curl -k \
   -u <USER> \

--- a/api/descriptions/credentials/get.md
+++ b/api/descriptions/credentials/get.md
@@ -1,4 +1,4 @@
-This endpoint will return a list in json format of the credentials found with the app here **Manage > Authentication > Credential Store**
+This endpoint will return a list in JSON format of the credentials found with the app here **Manage > Authentication > Credential Store**
 
 The following example curl command uses basic auth to return:
 

--- a/api/descriptions/credentials/id_usages_get.md
+++ b/api/descriptions/credentials/id_usages_get.md
@@ -1,4 +1,4 @@
-This endpoint will return a list in json format of all the usages of credentials found with the app here **Manage > Authentication > Credential Store**
+This endpoint will return a list in JSON format of all the usages of credentials found with the app here **Manage > Authentication > Credential Store**
 
 The following example curl command uses basic auth to return:
 

--- a/api/descriptions/credentials/post.md
+++ b/api/descriptions/credentials/post.md
@@ -1,6 +1,7 @@
-This endpoint will allow for update of the credentials found with the app here **Manage > Authentication > Credential Store**
+Updates the credentials in the credentials store.
+In the Console UI, you can view the credentials store here: **Manage > Authentication > Credential Store**.
 
-Create credentials.json file (example)
+Create `credentials.json` file (example):
 
 ```json
 [
@@ -15,7 +16,7 @@ Create credentials.json file (example)
 ]
 ```
 
-The following example curl command uses basic auth to update the checks:
+Example curl command:
 
 ```bash
 $ curl -k \

--- a/api/descriptions/custom-compliance/custom-compliance.md
+++ b/api/descriptions/custom-compliance/custom-compliance.md
@@ -1,3 +1,9 @@
-Custom image checks give you a way to write and run your own compliance checks to assess, measure, and enforce security baselines in your environment. Although Twistlock supports OpenSCAP and XCCDF, these frameworks are complicated, and they can be overkill when all you want to do is run a simple check. Twistlock lets you implement your own custom image checks with simple scripts.
+Custom image checks give you a way to write and run your own compliance checks to assess, measure, and enforce security baselines in your environment.
+Although Twistlock supports OpenSCAP and XCCDF, these frameworks are complicated, and they can be overkill when all you want to do is run a simple check.
+Twistlock lets you implement your own custom image checks with simple scripts.
 
-A custom image check consists of a single script. The script’s exit code determines the result of the check, where 0 is pass and 1 is fail. Scripts are executed in the container’s default shell. For many Linux container images, the default shell is bash, but that’s not always the case. For Windows container images, the default shell is cmd.exe.
+A custom image check consists of a single script.
+The script’s exit code determines the result of the check, where 0 is pass and 1 is fail.
+Scripts are executed in the container’s default shell.
+For many Linux container images, the default shell is bash, but that’s not always the case.
+For Windows container images, the default shell is `cmd.exe`.

--- a/api/descriptions/custom-compliance/get.md
+++ b/api/descriptions/custom-compliance/get.md
@@ -1,6 +1,7 @@
-This endpoint will return a list in json format of all the custom compliance checks found with the app here **Defend > Compliance > Custom**
+Returns a list of all custom compliance checks.
+In the Console UI, custom compliance checks can be found in **Defend > Compliance > Custom**.
 
-The following example curl command uses basic auth to return:
+The following example curl command gets the list of custom compliance checks:
 
 ```bash
 $ curl -k \
@@ -10,7 +11,7 @@ $ curl -k \
   https://<CONSOLE>:8083/api/v1/custom-compliance
 ```
 
-An example returned json could be something similar to:
+Example response:
 
 ```
 [

--- a/api/descriptions/custom-compliance/put.md
+++ b/api/descriptions/custom-compliance/put.md
@@ -1,6 +1,6 @@
 This endpoint will allow for update of the custom compliance checks on page **Defend > Compliance > Custom**
 
-Create custom_check.json file (example)
+Create `custom_check.json` file (example):
 
 ```
 [

--- a/api/descriptions/cves/get.md
+++ b/api/descriptions/cves/get.md
@@ -1,9 +1,9 @@
-Retrieves CVEs from Twistlock's vulnernability database.
+Retrieves CVEs from Twistlock's vulnerability database.
 Query the database by CVE ID.
 Partial matches are supported.
 A null response indicates that the CVE is not in our database.
 
-The following example curl command queries the Twistlock database for CVE-2018-1102.
+The following example curl command queries the Twistlock database for `CVE-2018-1102`.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/defenders/image-name_get.md
+++ b/api/descriptions/defenders/image-name_get.md
@@ -1,6 +1,6 @@
 Returns the full Docker image name for Defender.
 
-Example: registry-auth.twistlock.com/tw_smbvukudjypnnrqmso0/twistlock/defender:defender_18_11_128
+Example: `registry-auth.twistlock.com/tw_smbvukudjypnnrqmso0/twistlock/defender:defender_18_11_128`
 
 ```bash
 $ curl -k \

--- a/api/descriptions/defenders/install-bundle_get.md
+++ b/api/descriptions/defenders/install-bundle_get.md
@@ -1,4 +1,4 @@
-Returns the certsBundle that Defender needs to securely connect to Console.
+Returns the certificate bundle that Defender needs to securely connect to Console.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/defenders/rasp_post.md
+++ b/api/descriptions/defenders/rasp_post.md
@@ -1,7 +1,4 @@
-Creates an augumented dockerfile with RASP defender and dependencides included as a zip file.]
-
-For more information about how to use this endpoint, see
-[Deploy a Defender RASP using the API](https://docs.twistlock.com/docs/19.07/install/install_defender/install_rasp_defender.html#embed-rasp-defender).
+Creates an augmented Dockerfile with RASP Defender and dependencies included as a ZIP file.
 
 The following example curl command returns a RASP Defender zip file.
 The `<HOSTNAME>` query parameter specifies the address that Defender uses to communicate with Console.

--- a/api/descriptions/defenders/upgrade_post.md
+++ b/api/descriptions/defenders/upgrade_post.md
@@ -1,7 +1,7 @@
 Upgrades all connected single Linux Container Defenders.
 
 This does not update cluster Container Defenders (such as Defender DaemonSets), Serverless Defenders, or Fargate Defenders.
-To upgrade cluster Container Defenders, reploy them.
+To upgrade cluster Container Defenders, redeploy them.
 To upgrade Serverless and Fargate Defenders, re-embed them.
 
 ```bash

--- a/api/descriptions/entitySchema.md
+++ b/api/descriptions/entitySchema.md
@@ -1,5 +1,0 @@
-We provide schemas for all entities referenced in these API docs. Please note that entities might contain different properties than the schema, i.e. they might have additional properties (not documented ones) or might have missing some of the optional properties.
-
-We explicitly document **ONLY** the properties we think should be used by external systems and we will keep compatibility when rolling out new versions of the API. All not documented properties are considered internal for the system and might be subject of change without changing the API version or notification.
-
-This means you **should not use any properties which are not included in the entity schema** as they are considered internal for the system.

--- a/api/descriptions/feeds/cve_allow_list_get.md
+++ b/api/descriptions/feeds/cve_allow_list_get.md
@@ -1,8 +1,8 @@
-Retrieves the list of globally whitelisted Common Vulnerabilities and Exposures (CVE).
+Retrieves the globally allow-listed Common Vulnerabilities and Exposures (CVE).
 
 ### cURL Request
 
-The following cURL command retrieves the globally whitelisted CVE list.
+The following cURL command retrieves the globally allow-listed CVEs.
 
 ```bash
 $ curl -k \
@@ -14,7 +14,7 @@ $ curl -k \
 
 ### Response
 
-A successful response will return a CVE list that will be used for global whitelisting.
+A successful response returns all CVEs globally allow-listed.
 
 ```json
 {

--- a/api/descriptions/feeds/cve_allow_list_put.md
+++ b/api/descriptions/feeds/cve_allow_list_put.md
@@ -1,10 +1,10 @@
-Globally whitelists a set of Common Vulnerabilities and Exposures (CVE).
+Globally allow-lists a set of Common Vulnerabilities and Exposures (CVE).
 
 **Note:** Any previously installed lists are overwritten.
 
 ### cURL Request
 
-The following cURL command installs a globally whitelisted CVE list.
+The following cURL command installs a global CVE allow-list.
 
 ```bash
 $ curl -k \
@@ -25,5 +25,5 @@ $ curl -k \
 
 **Note:** No response will be returned upon successful execution.
 
-To confirm the CVE list has been added to the global whitelist, invoke the `GET /api/v1/feeds/custom/cve-allow-list` endpoint.
+To confirm the CVE list has been added to the global allow-list, call the `GET /api/v1/feeds/custom/cve-allow-list` endpoint.
 

--- a/api/descriptions/feeds/ips_get.md
+++ b/api/descriptions/feeds/ips_get.md
@@ -1,8 +1,8 @@
-Retrieves the customized list of blacklisted suspicious or high-risk IP addresses.
+Retrieves the customized list of block-listed suspicious or high-risk IP addresses.
 
 ### cURL Request
 
-The following cURL command retrieves the list of globally blacklisted suspicious or high-risk IP addresses.
+The following cURL command retrieves the list of globally block-listed suspicious or high-risk IP addresses.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/forensic/activities_download_get.md
+++ b/api/descriptions/forensic/activities_download_get.md
@@ -1,4 +1,4 @@
-Downloads all host activities that can be found on *Monitor > Evenets > Host Activities*
+Downloads all host activities that can be found on *Monitor > Events > Host Activities*
 
 Use the query parameters to filter what data is returned.
 

--- a/api/descriptions/forensic/activities_get.md
+++ b/api/descriptions/forensic/activities_get.md
@@ -1,4 +1,4 @@
-Retrieves all host activities that can be found on *Monitor > Evenets > Host Activities*
+Retrieves all host activities that can be found on *Monitor > Events > Host Activities*.
 
 Use the query parameters to filter what data is returned.
 

--- a/api/descriptions/groups/get.md
+++ b/api/descriptions/groups/get.md
@@ -1,7 +1,5 @@
 Retrieves a list of all groups.
 
-A curl command to access this endpoint may resemble the following code snippet:
-
 ```bash
 $ curl -k \
   -X GET \

--- a/api/descriptions/groups/id_delete.md
+++ b/api/descriptions/groups/id_delete.md
@@ -1,6 +1,5 @@
-Deletes a group from the system. The id's can be retrieved with a GET from the /group/ api endpoint.
-
-A call to this api endpoint may resemble the following code snippet:
+Deletes a group from the system.
+The `id` can be retrieved from the `GET /api/v1/groups` endpoint.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/groups/id_put.md
+++ b/api/descriptions/groups/id_put.md
@@ -1,6 +1,5 @@
-Adds or modifies a group from the system. The id's can be retrieved with a GET from the /group/ api endpoint.
-
-A call to this api endpoint may resemble the following code snippet:
+Adds or modifies a group from the system.
+The `id` can be retrieved with from the `GET /api/v1/groups` endpoint.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/groups/names.md
+++ b/api/descriptions/groups/names.md
@@ -1,7 +1,5 @@
 Returns the names of all groups as strings in an array.
 
-A curl command to access this endpoint may resemble the following code snippet:
-
 ```bash
 $ curl -X GET \
   https://<CONSOLE>:8083/api/v1/groups/names \

--- a/api/descriptions/images/download_get.md
+++ b/api/descriptions/images/download_get.md
@@ -12,4 +12,4 @@ $ curl -k \
   > images.csv
 ```
 
-Where an example &lt;IMAGE_ID&gt; would be `sha256:abd4f451ddb707c8e68a36d695456a515cdd6f9581b7a8348a380030a6fd7689`.
+Where an example `IMAGE_ID` would be `sha256:abd4f451ddb707c8e68a36d695456a515cdd6f9581b7a8348a380030a6fd7689`.

--- a/api/descriptions/images/get.md
+++ b/api/descriptions/images/get.md
@@ -14,7 +14,7 @@ $ curl -k \
   "https://<CONSOLE>:8083/api/v1/images"
 ```
 
-The following example curl command uses basic auth to retrieve the compact scan report for the ubuntu image.
+The following example curl command uses basic auth to retrieve the compact scan report for the Ubuntu image.
 The name query is synonymous with the "Search Images" field in the Console UI.
 
 ```

--- a/api/descriptions/images/images.md
+++ b/api/descriptions/images/images.md
@@ -1,3 +1,3 @@
 Image scan reports.
 
-Note that the compliance issues in an image might be different (fewer) than those in a running instance of the image (i.e. a container).
+Note that the compliance issues in an image might be different (fewer) than those in a running instance of the image (a container).

--- a/api/descriptions/logs/defender_get.md
+++ b/api/descriptions/logs/defender_get.md
@@ -1,8 +1,8 @@
 Retrieves the latest log messages for a given Defender.
 The Defender is specified by the host where it runs.
-You can retrieve the hostname for each Defender from the GET /api/v1/defenders endpoint.
+You can retrieve the hostname for each Defender from the `GET /api/v1/defenders` endpoint.
 
-The following example curl command retrieves the 10 log messages for the Defender that runs on worker.sandbox.internal.
+The following example curl command retrieves the 10 log messages for the Defender that runs on `worker.sandbox.internal`.
 Note that you must quote the URL when running the following command.
 Otherwise the shell misinterprets the ampersand (`&`) as the end of the command, and puts the curl command in the background.
 

--- a/api/descriptions/pcf-droplets/addresses_get.md
+++ b/api/descriptions/pcf-droplets/addresses_get.md
@@ -1,6 +1,6 @@
-This endpoint will return the cloud contoller addresses configured for PCF Blobstore scanning.
+This endpoint will return the cloud controller addresses configured for PCF Blobstore scanning.
 
-You can also add optional query paramaters to this api call, in this example `cloudControllerAddresses` and/or `id`
+You can also add optional query parameters to this API call, in this example `cloudControllerAddresses` and/or `id`
 
 The following example curl command retrieves the list of addresses:
 

--- a/api/descriptions/pcf-droplets/download_get.md
+++ b/api/descriptions/pcf-droplets/download_get.md
@@ -1,6 +1,6 @@
 This endpoint will download the list of configured cloud controller addresses configured for PCF Blobstore scanning.
 
-The following example curl command retrieves the list of addresses and outputs it to a file call PCF_blobstores.csv:
+The following example curl command retrieves the list of addresses and outputs it to a file call `PCF_blobstores.csv`:
 
 ```bash
 $ curl -k \

--- a/api/descriptions/pcf-droplets/get.md
+++ b/api/descriptions/pcf-droplets/get.md
@@ -1,4 +1,4 @@
-This endpoint will return the full metadata of pcf blobstore from page **Monitor > Vulnerabilities > PCF** within the Console.
+This endpoint will return the full metadata of PCF blobstore from page **Monitor > Vulnerabilities > PCF** within the Console.
 
 The following example curl command will retrieve this:
 

--- a/api/descriptions/pcf-droplets/pcf-droplets.md
+++ b/api/descriptions/pcf-droplets/pcf-droplets.md
@@ -1,3 +1,3 @@
-Scan reports for the VMware Tanzu Application Service (TAS) droplets in your blobstore(s).
+Scan reports for the VMWare Tanzu Application Service (TAS) droplets in your blobstore(s).
 Droplets are archives that contain ready to run applications.
 They contain an OS stack, a buildpack (which contains the languages, libraries, and services used by the app), and custom app code.

--- a/api/descriptions/policies/compliance_container_impacted_get.md
+++ b/api/descriptions/policies/compliance_container_impacted_get.md
@@ -5,7 +5,7 @@ To see where Console invokes this endpoint:
 
 * In Console, go to **Defend > Compliance > Containers and images > Deployed**.
 * In the **Compliance rules** section, click **Show** under the **Entities in scope** column for a rule.
-* The endpoint is invoked when the popup is displayed.
+* The endpoint is invoked when the pop-up is displayed.
 
 ### cURL Request
 

--- a/api/descriptions/policies/docker_put.md
+++ b/api/descriptions/policies/docker_put.md
@@ -18,7 +18,7 @@ The procedure to add, edit, or remove Docker access control rules is:
 
 3. Update rules by pushing the new JSON payload.
 
-   The following curl command installs the rules defined in your *docker_access_control_rules.json* file.
+   The following curl command installs the rules defined in your `docker_access_control_rules.json` file.
    Do not forget to specify the `@` symbol.
 
    ```

--- a/api/descriptions/policies/firewall_app_container_put.md
+++ b/api/descriptions/policies/firewall_app_container_put.md
@@ -18,7 +18,7 @@ The procedure to add, edit, or remove application firewall rules is:
 
 3. Update rules by pushing the new JSON payload.
 
-   The following curl command installs the rules defined in your *app_firewall_rules.json* file.
+   The following curl command installs the rules defined in your `app_firewall_rules.json` file.
    Do not forget to specify the `@` symbol.
 
    ```

--- a/api/descriptions/policies/firewall_app_rasp_put.md
+++ b/api/descriptions/policies/firewall_app_rasp_put.md
@@ -18,7 +18,7 @@ The procedure to add, edit, or remove rules is:
 
 3. Update rules by pushing the new JSON payload.
 
-   The following curl command installs the rules defined in your *app_firewall_rules.json* file.
+   The following curl command installs the rules defined in your `app_firewall_rules.json` file.
    Do not forget to specify the `@` symbol.
 
    ```

--- a/api/descriptions/policies/firewall_network_container_put.md
+++ b/api/descriptions/policies/firewall_network_container_put.md
@@ -18,7 +18,7 @@ The procedure to add, edit, or remove rules is:
 
 3. Update rules by pushing the new JSON payload.
 
-   The following curl command installs the rules defined in your *network_firewall_rules.json* file.
+   The following curl command installs the rules defined in your `network_firewall_rules.json` file.
    Do not forget to specify the `@` symbol.
 
    ```

--- a/api/descriptions/policies/policies.md
+++ b/api/descriptions/policies/policies.md
@@ -123,7 +123,7 @@ To construct an effective rule for a compliance policy:
 A check is a security best practice or baseline setting which will be validated by the scanner.
 
 2. Specify an action for each check.
-Prisma Cloud needs to know what to do when a check fails (e.g. alert, block).
+Prisma Cloud needs to know what to do when a check fails (for example, alert or block).
 
 3. In the `effect` parameter, specify the range of possible actions configured in the rule.
 The value in `effect` a comma-separated list.

--- a/api/descriptions/policies/runtime_container_impacted_get.md
+++ b/api/descriptions/policies/runtime_container_impacted_get.md
@@ -1,4 +1,5 @@
-Returns the impacted images based on this {ruleName}, which can be seen on page defend/runtime/container-policy when you click on the Show link.
+Returns the impacted images based on a given rule
+In the Console UI, you can see how it works by going to the **Defend > Runtime > Container policy** page and clicking the **Show** link.
 
 Example curl command:
 
@@ -10,7 +11,7 @@ $ curl -k \
   https://<CONSOLE>:8083/api/v1/policies/runtime/container/impacted?ruleName={ruleName}
 ```
 
-For additional help with your {ruleName}:
+For additional help with your `ruleName`:
 
 ```bash
 $ curl -k -G \

--- a/api/descriptions/policies/runtime_container_put.md
+++ b/api/descriptions/policies/runtime_container_put.md
@@ -1,7 +1,7 @@
 Updates the runtime policy for containers.
 All rules in the policy are updated in a single shot.
 
-Prisma Cloud automatically builds whitelist security models for each container image in your environment.
+Prisma Cloud automatically builds allow-list security models for each container image in your environment.
 Use runtime container rules to augment the rules in those models.
 Manually defined rules augment learned models as follows:
 

--- a/api/descriptions/policies/runtime_rasp_put.md
+++ b/api/descriptions/policies/runtime_rasp_put.md
@@ -20,7 +20,7 @@ The procedure to add, edit, or remove rules is:
 
 3. Update rules by pushing the new JSON payload.
 
-   The following curl command installs the rules defined in your *rasp_runtime_rules.json* file.
+   The following curl command installs the rules defined in your `rasp_runtime_rules.json` file.
    Do not forget to specify the `@` symbol.
 
    ```

--- a/api/descriptions/policies/secrets_put.md
+++ b/api/descriptions/policies/secrets_put.md
@@ -20,7 +20,7 @@ The procedure to add, edit, or remove secrets rules is:
 
 3. Update rules by pushing the new JSON payload.
 
-   The following curl command installs the rules defined in your *secrets_rules.json* file.
+   The following curl command installs the rules defined in your `secrets_rules.json` file.
    Do not forget to specify the `@` symbol.
 
    ```

--- a/api/descriptions/policies/vulnerability_coderepos_impacted_get.md
+++ b/api/descriptions/policies/vulnerability_coderepos_impacted_get.md
@@ -4,7 +4,7 @@ To see where Console invokes this endpoint:
 
 * In Console, go to **Defend > Vulnerabilities**.
 * In the **Vulnerability rules** section, click **Show** under the **Entities in scope** column for a rule.
-* The endpoint is invoked when the popup is displayed.
+* The endpoint is invoked when the pop-up is displayed.
 
 ### cURL Request
 

--- a/api/descriptions/policies/vulnerability_host_impacted_get.md
+++ b/api/descriptions/policies/vulnerability_host_impacted_get.md
@@ -5,7 +5,7 @@ To see where Console invokes this endpoint:
 * In Console, go to **Defend > Vulnerabilities**.
 * Select the **Hosts** tab.
 * In the **Vulnerability rules** section, click **Show** under the **Entities in scope** column for a rule.
-* The endpoint is invoked when the popup is displayed.
+* The endpoint is invoked when the pop-up is displayed.
 
 ### cURL Request
 

--- a/api/descriptions/policies/vulnerability_images_impacted_get.md
+++ b/api/descriptions/policies/vulnerability_images_impacted_get.md
@@ -4,7 +4,7 @@ To see where Console invokes this endpoint:
 
 * In Console, go to **Defend > Vulnerabilities > Images > Deployed**.
 * In the policy table, click **Show** under the **Entities in scope** column for a rule.
-* The endpoint is invoked when the popup is displayed.
+* The endpoint is invoked when the pop-up is displayed.
 
 ### cURL Request
 

--- a/api/descriptions/policies/vulnerability_vms_impacted_get.md
+++ b/api/descriptions/policies/vulnerability_vms_impacted_get.md
@@ -5,7 +5,7 @@ To see where Console invokes this endpoint:
 * In Console, go to **Defend > Vulnerabilities > Hosts**.
 * Select the **VM images** tab.
 * In the **Vulnerability rules** section, click **Show** under the **Entities in scope** column for a rule.
-* The endpoint is invoked when the popup is displayed.
+* The endpoint is invoked when the pop-up is displayed.
 
 ### cURL Request
 

--- a/api/descriptions/profiles/container_download_get.md
+++ b/api/descriptions/profiles/container_download_get.md
@@ -1,6 +1,6 @@
 Retrieves the details and state of all runtime models in CSV format
 
-The following example command uses curl to downlad a complete list in CSV format.
+The following example command uses curl to download a complete list in CSV format.
 
 NOTE: the -o option can help with saving the data to a file
 

--- a/api/descriptions/profiles/container_id_forensic_bundle_get.md
+++ b/api/descriptions/profiles/container_id_forensic_bundle_get.md
@@ -1,6 +1,7 @@
-Returns the forensic data for a container, which can be used to investigate runtime incidents.  This will return a tar.gz file as a zipped file.
+Returns the forensic data for a container, which can be used to investigate runtime incidents.
+This will return a `tar.gz` file.
 
-The following example command retrieves forensic data for a specific container, where `id` is the profle ID (model) that Twistlock created for the container, and `hostname` is the machine where the Defender detected the incident.
+The following example command retrieves forensic data for a specific container, where `id` is the profile ID (model) that Twistlock created for the container, and `hostname` is the machine where the Defender detected the incident.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/profiles/container_id_forensic_get.md
+++ b/api/descriptions/profiles/container_id_forensic_get.md
@@ -1,6 +1,6 @@
 Returns the forensic data for a container, which can be used to investigate runtime incidents.
 
-The following example command retrieves forensic data for a specific container, where `id` is the profle ID (model) that Twistlock created for the container, and `hostname` is the machine where the Defender detected the incident.
+The following example command retrieves forensic data for a specific container, where `id` is the profile ID (model) that Twistlock created for the container, and `hostname` is the machine where the Defender detected the incident.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/profiles/container_id_hosts_get.md
+++ b/api/descriptions/profiles/container_id_hosts_get.md
@@ -1,11 +1,11 @@
 Return the host/hosts where this container is running.
 
-To get the PROFILE_ID for a profile:
+To get the `PROFILE_ID` for a profile:
 
-1. Retrieve a list of profiles using the GET method on the */api/v1/profiles/container* endpoint.
+1. Retrieve a list of profiles using the GET method on the `/api/v1/profiles/container` endpoint.
 
 2. For the profile of interest, copy the value in `_id`.
-This is the PROFILE_ID.
+This is the `PROFILE_ID`.
 
 The following example command uses curl and basic auth to specify the learning mode for a profile.
 

--- a/api/descriptions/profiles/container_id_learn_post.md
+++ b/api/descriptions/profiles/container_id_learn_post.md
@@ -1,11 +1,11 @@
 Specify the learning mode for a profile.
 
-To get the PROFILE_ID for a profile:
+To get the `PROFILE_ID` for a profile:
 
-1. Retrieve a list of profiles using the GET method on the */api/v1/profiles/container* endpoint.
+1. Retrieve a list of profiles using the GET method on the `/api/v1/profiles/container` endpoint.
 
 2. For the profile of interest, copy the value in `_id`.
-This is the PROFILE_ID.
+This is the `PROFILE_ID`.
 
 The following example command uses curl and basic auth to specify the learning mode for a profile.
 

--- a/api/descriptions/profiles/container_id_rule_get.md
+++ b/api/descriptions/profiles/container_id_rule_get.md
@@ -1,11 +1,11 @@
 Return the runtime rule/policy that is associated with this container.
 
-To get the PROFILE_ID for a profile:
+To get the `PROFILE_ID` for a profile:
 
-1. Retrieve a list of profiles using the GET method on the */api/v1/profiles/container* endpoint.
+1. Retrieve a list of profiles using the GET method on the `/api/v1/profiles/container` endpoint.
 
 2. For the profile of interest, copy the value in `_id`.
-This is the PROFILE_ID.
+This is the `PROFILE_ID`.
 
 The following example command uses curl and basic auth to specify the learning mode for a profile.
 

--- a/api/descriptions/profiles/host_get.md
+++ b/api/descriptions/profiles/host_get.md
@@ -1,12 +1,16 @@
 Retrieves the details and state of each host service runtime model on a host-by-host basis.
 The returned JSON object has the following structure:
 
+```
 * host1:
   * service1: model
   * service2: model
 * host2:
   * service1: model
   * service3: model
+```
+
+Example curl command:
 
 ```bash
 $ curl -k \

--- a/api/descriptions/profiles/host_id_rule_get.md
+++ b/api/descriptions/profiles/host_id_rule_get.md
@@ -1,11 +1,11 @@
 Return the runtime rule/policy that is associated with this host.
 
-To get the PROFILE_ID for a profile:
+To get the `PROFILE_ID` for a profile:
 
-1. Retrieve a list of profiles using the GET method on the */api/v1/profiles/host* endpoint.
+1. Retrieve a list of profiles using the GET method on the `/api/v1/profiles/host` endpoint.
 
 2. For the profile of interest, copy the value in `_id`.
-This is the PROFILE_ID.
+This is the `PROFILE_ID`.
 
 The following example command uses curl and basic auth to specify the learning mode for a profile.
 

--- a/api/descriptions/profiles/service_get.md
+++ b/api/descriptions/profiles/service_get.md
@@ -1,9 +1,13 @@
 Retrieves the details and state of all host service runtime models.
 The returned JSON object has the following structure:
-  
+
+```  
 * service1: model
 * service2: model
 * service3: model
+```
+
+Example curl command:
 
 ```bash
 $ curl -k \

--- a/api/descriptions/profiles/service_id_learn_post.md
+++ b/api/descriptions/profiles/service_id_learn_post.md
@@ -1,12 +1,12 @@
 Specify the learning mode for a host service profile.
 
-To get the PROFILE_ID for a profile:
+To get the `PROFILE_ID` for a profile:
 
-1. Retrieve a list of profiles using the GET method on the */api/v1/profiles/service* endpoint.
+1. Retrieve a list of profiles using the GET method on the `/api/v1/profiles/service` endpoint.
 
 2. For the profile of interest, copy the value in `_id`.
-This is the PROFILE_ID.
-The PROFILE_ID is typically the service's name, such as `sshd` or `ntpd`.
+This is the `PROFILE_ID`.
+The `PROFILE_ID` is typically the service's name, such as `sshd` or `ntpd`.
 
 The following example command uses curl and basic auth to specify the learning mode for a host service profile.
 

--- a/api/descriptions/profiles/service_names_get.md
+++ b/api/descriptions/profiles/service_names_get.md
@@ -1,4 +1,4 @@
-Retrieves the name of all host service runtime models from withign the app at **Monitor > Runtime > Host-models**
+Retrieves the name of all host service runtime models from within the app at **Monitor > Runtime > Host-models**.
 
 The following example curl command uses basic auth to retrieve this data:
 

--- a/api/descriptions/projects/name_delete.md
+++ b/api/descriptions/projects/name_delete.md
@@ -1,7 +1,7 @@
 Deletes a project from the system.
 
 The following example curl command deletes a project named `<PROJECT_NAME>`.
-The value for `<PROJECT_NAME>` can be retrieved from the `_id` field in the response object from *GET /api/v1/projects*.
+The value for `<PROJECT_NAME>` can be retrieved from the `_id` field in the response object from `GET /api/v1/projects`.
 
 The DELETE method returns the decommissioned supervisor's admin username and password.
 

--- a/api/descriptions/projects/name_put.md
+++ b/api/descriptions/projects/name_put.md
@@ -1,8 +1,7 @@
 Updates a project.
 
 The following example curl command updates a project named `<PROJECT_NAME>`.
-The value for `<PROJECT_NAME>` can be retrieved from the `_id` field in the response object from *GET /api/v1/projects*.
-
+The value for `<PROJECT_NAME>` can be retrieved from the `_id` field in the response object from `GET /api/v1/projects`.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/projects/projects.md
+++ b/api/descriptions/projects/projects.md
@@ -1,6 +1,6 @@
 Manage [Projects](https://docs.twistlock.com/docs/latest/deployment_patterns/projects.html).
 
-Before you can provision a project using this endpoint, you must designate one instance of Console as master using the *POST /api/v1/settings/projects* endpoint.
+Before you can provision a project using this endpoint, you must designate one instance of Console as master using the `POST /api/v1/settings/projects` endpoint.
 
 #### Accessing the REST API of a supervisor Console
 
@@ -17,7 +17,7 @@ To retrieve data from a project, add the the following query parameter to your r
 Where the default value for `project` is `Central+Console`.
 If `project` is not specified, it is set to `Central+Console`.
 
-For example, to retrieve the compliance policies for a tenant project named *mobile_payments_division*, use the following curl command:
+For example, to retrieve the compliance policies for a tenant project named `mobile_payments_division`, use the following curl command:
 
 ```
 curl -k \
@@ -36,24 +36,24 @@ The following user management endpoints can be accessed from Central Console onl
 An administrator centrally manages all users, and specifies who has access to which projects.
 These calls are handled by Central Console only.
 
-* /api/v1/users
-* /api/v1/groups
-* /api/v1/projects
+* `/api/v1/users`
+* `/api/v1/groups`
+* `/api/v1/projects`
 
 The following endpoints are proxied to the relevant supervisor for tenant projects only.
 
-* /api/v1/policies
-* /api/v1/trust
-* /api/v1/settings
-* /api/v1/collections
-* /api/v1/feeds
+* `/api/v1/policies`
+* `/api/v1/trust`
+* `/api/v1/settings`
+* `/api/v1/collections`
+* `/api/v1/feeds`
 
 The following endpoints are proxied to the relevant supervisor for both tenant and scale projects:
 
-* /api/v1/settings/alerts
-* /api/v1/alert-profiles
-* /api/v1/settings/regisry
-* /api/v1/settings/certs
-* /api/v1/settings/secrets
-* /api/v1/policies/secrets
+* `/api/v1/settings/alerts`
+* `/api/v1/alert-profiles`
+* `/api/v1/settings/regisry`
+* `/api/v1/settings/certs`
+* `/api/v1/settings/secrets`
+* `/api/v1/policies/secrets`
 

--- a/api/descriptions/recovery/backup_id_delete.md
+++ b/api/descriptions/recovery/backup_id_delete.md
@@ -1,7 +1,6 @@
 Deletes a given backup by name.
 
-{file_name_of_backup} = {backup_name}-18.11.128-1551386737.tar.gz
-
+`{file_name_of_backup} = {backup_name}-18.11.128-1551386737.tar.gz`
 
 Example curl command:
 

--- a/api/descriptions/recovery/backup_id_patch.md
+++ b/api/descriptions/recovery/backup_id_patch.md
@@ -1,7 +1,6 @@
 Deletes a given backup by name.
 
-{file_name_of_backup} = {backup_name}-18.11.128-1551386737.tar.gz
-
+`{file_name_of_backup} = {backup_name}-18.11.128-1551386737.tar.gz`
 
 Example curl command:
 

--- a/api/descriptions/recovery/backup_post.md
+++ b/api/descriptions/recovery/backup_post.md
@@ -1,4 +1,4 @@
-Creates a backup named {backup_name} by invoking the MongoDB dump process.
+Creates a backup named `backup_name` by invoking the MongoDB dump process.
 
 Example curl command:
 

--- a/api/descriptions/recovery/restore_id_post.md
+++ b/api/descriptions/recovery/restore_id_post.md
@@ -1,7 +1,6 @@
 Restores Twistlock from the given backup.
 
-{file_name_of_backup} = {backup_name}-18.11.128-1551386737.tar.gz
-
+`{file_name_of_backup} = {backup_name}-18.11.128-1551386737.tar.gz`
 
 Example curl command:
 

--- a/api/descriptions/registry/download_get.md
+++ b/api/descriptions/registry/download_get.md
@@ -1,6 +1,6 @@
-Downloads all image scan reports in CSV format. You can redirect the output of the request to a csv file.
+Downloads all image scan reports in CSV format. You can redirect the output of the request to a CSV file.
 
-The following example curl command uses basic auth to retrieve and save your console's registry scan report to a csv file called `registry_report.csv`:
+The following example curl command uses basic auth to retrieve and save your console's registry scan report to a CSV file called `registry_report.csv`:
 
 ```bash
 $ curl -k \

--- a/api/descriptions/registry/get.md
+++ b/api/descriptions/registry/get.md
@@ -16,7 +16,8 @@ $ curl -k \
 ```
 
 The compact query can also be used to get a general overview of the number of Vulnerabilities and Compliance issue counts instead of listing all of CVEs and compliance violations.
-The following example curl command uses basic auth to retrieve the compact scan report for the ubuntu image in the registry.  The name query is synonymous with the **Search Registry** field in the Console UI:
+The following example curl command uses basic auth to retrieve the compact scan report for the Ubuntu image in the registry.
+The name query is synonymous with the **Search Registry** field in the Console UI:
 
 ```bash
 $ curl -k \

--- a/api/descriptions/scans/download_get.md
+++ b/api/descriptions/scans/download_get.md
@@ -1,7 +1,7 @@
-Retrieves all scan reports for either Jenkins plugin or twistcli scans in csv format. In the console, this would be the equivalent of pressing the 
-**CSV** download button in **Monitor > Vulnerabilities > Jenkins Jobs** and **Monitor > Vulnerabilities > Twistcli Scans**.
+Retrieves all scan reports from the Jenkins plugin and twistcli in CSV format.
+In Console, this would be the equivalent of clicking the **CSV** download button in **Monitor > Vulnerabilities > Jenkins Jobs** and **Monitor > Vulnerabilities > Twistcli Scans**.
 
-The following example curl command uses basic auth to retrieve and save your console's Jenkins and twistcli scan reports to a csv file called `registry_report.csv`:
+The following example curl command retrieves and saves your Jenkins and twistcli scan reports to a CSV file called `registry_report.csv`:
 
 ```bash
 $ curl -k \

--- a/api/descriptions/serverless/download_get.md
+++ b/api/descriptions/serverless/download_get.md
@@ -1,6 +1,6 @@
-Downloads all serveless scan reports in CSV format.
+Downloads all serverless scan reports in CSV format.
 
-The following curl command uses basic auth to retrieve a list of all Serverless resources that monitored by Twistlock, and save the results to a CSV file:
+The following curl command retrieves a list of all serverless resources monitored by Twistlock and saves the results in a CSV file:
 
 ```bash
 $ curl -k \

--- a/api/descriptions/settings/certs_post.md
+++ b/api/descriptions/settings/certs_post.md
@@ -5,7 +5,7 @@ SANs are set in a single shot.
 You should first retrieve the list of SANs with the GET method.
 Then add or remove entries from the `consoleSAN` array, and post the updated JSON object.
 
-The following example curl command uses basic auth to add node-01.example.com to the subjectAltName field in Console's certificate.
+The following example curl command uses basic auth to add `node-01.example.com` to the `subjectAltName` field in Console's certificate.
 
 ```bash
 curl -k \

--- a/api/descriptions/settings/console-certificate_post.md
+++ b/api/descriptions/settings/console-certificate_post.md
@@ -1,6 +1,6 @@
 This endpoint will enter custom certificates for securing browser access to the Console. These settings can be seen in the console under **Manage > Authentication > System Certificates**.
 
-For the custom TLS certificate for securing browser access, this file must be in the cocatenated public cert and private key in PEM format. For more information about this configuration, see [Custom certs for Console access](https://docs.twistlock.com/docs/latest/configure/custom_certs_console_access.html)
+For the custom TLS certificate for securing browser access, this file must be in the concatenated public cert and private key in PEM format. For more information about this configuration, see [Custom certs for Console access](https://docs.twistlock.com/docs/latest/configure/custom_certs_console_access.html)
 
 The following example curl command uses basic auth enter the custom certificate to use for securing browser access to the console:
 

--- a/api/descriptions/settings/defender_post.md
+++ b/api/descriptions/settings/defender_post.md
@@ -1,6 +1,6 @@
-This endpoint will allow you to manage the advanced settings from **Manage > Defenders > Mangage** page in the console.
+This endpoint will allow you to manage the advanced settings from **Manage > Defenders > Manage** page in the console.
 
-The following example curl command uses basic auth to set the local defender API port to `9998`, turn on Defender runc proxy, and set the number of days to automatically remove disconnected defenders to `4`:
+The following example curl command uses basic auth to set the local defender API port to `9998`, turn on the Defender runC proxy, and set the number of days to automatically remove disconnected defenders to `4`:
 
 ```bash
 $ curl -k \

--- a/api/descriptions/settings/license_post.md
+++ b/api/descriptions/settings/license_post.md
@@ -1,5 +1,5 @@
 Sets up your Twistlock license.
-Use this endpoint, along with /api/v1/signup, as part of the initial set up flow after Twistlock is first installed.
+Use this endpoint, along with `/api/v1/signup`, as part of the initial set up flow after Twistlock is first installed.
 
 The following example curl command uses basic auth to set your license.
 

--- a/api/descriptions/settings/logging_post.md
+++ b/api/descriptions/settings/logging_post.md
@@ -1,6 +1,6 @@
 Configure your logging settings. This includes Syslog, Stdout, and Prometheus instrumentation.
 
-The following example curl command uses basic auth to turn on "syslog" with "VerboseScan" and "stdout" with "VerboseScan".
+The following example curl command enables verbose scan output for syslog and stdout.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/settings/saml_post.md
+++ b/api/descriptions/settings/saml_post.md
@@ -1,6 +1,6 @@
 This endpoint let's you configure SAML settings configured to authenticate to the Twistlock console.
 
-The following example curl command uses basic auth to set up enable SAML integration with Twistlock, set the Identity provider to ADFS, set the Identity provide single sign-on URL to `https://my-adfs-server.twistlock.com/adfs/SSO`, set the Identity provider issuer to `https://my-adfs-server.twistlock.com/adfs/services/trust`, set the x.509 Certificate to `CERTIFICATE`, and to set the audience to `twistlock`:
+The following example curl command uses basic auth to set up enable SAML integration with Twistlock, set the Identity provider to ADFS, set the Identity provide single sign-on URL to `https://my-adfs-server.twistlock.com/adfs/SSO`, set the Identity provider issuer to `https://my-adfs-server.twistlock.com/adfs/services/trust`, set the X.509 Certificate to `CERTIFICATE`, and to set the audience to `twistlock`:
 
 ```bash
 $ curl -k \

--- a/api/descriptions/settings/secrets_post.md
+++ b/api/descriptions/settings/secrets_post.md
@@ -2,7 +2,7 @@ This endpoint will updates your secret store settings found in the console under
 
 Please note the data structure returned from endpoint /settings/secrets GET to set in POST
 
-The following example curl command adds a cyberark secret store to the console with the appID set to `Twistlock_Console` and the URL set to `https://services-myca.twistlock.com:10882`:
+The following example curl command adds a CyberArk secret store to the console with the appID set to `Twistlock_Console` and the URL set to `https://services-myca.twistlock.com:10882`:
 
 ```bash
 $ curl -k \

--- a/api/descriptions/settings/trusted_certificate_post.md
+++ b/api/descriptions/settings/trusted_certificate_post.md
@@ -4,9 +4,9 @@ Use this endpoint to control how users authenticate to Twistlock.
 Users employ client certificates to authenticate commands sent from a Docker client through Twistlock.
 
 NOTE: You can only add a custom certificate if the trusted certificates mode is enabled.
-For more information, see the /settings/trusted-certificates endpoint.
+For more information, see the `/settings/trusted-certificates` endpoint.
 
-The following example curl command uses basic auth to add a ceritificate to the list:
+The following example curl command uses basic auth to add a certificate to the list:
 
 ```bash
 curl -k \

--- a/api/descriptions/static/syscalls_get.md
+++ b/api/descriptions/static/syscalls_get.md
@@ -1,5 +1,5 @@
 Returns a list of the Linux kernel system calls.
-Runtime rules for containers can whitelist and blacklist specific system calls.
+Runtime rules for containers can allow-list and deny-list specific system calls.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/static/vulnerabilities_get.md
+++ b/api/descriptions/static/vulnerabilities_get.md
@@ -1,6 +1,6 @@
-Returns a list of static compliance and vulnerability data.  This data can be used in building out reports with the API.  This data can be correlated with the endpoint */images* specifically *complianceVulnerabilities* and *cveVulnerabilities* within, to more thoroughly generate the reports.
-
-
+Returns a list of static compliance and vulnerability data.
+This data can be used for building out reports with the API.
+This data can be correlated with the `/api/v1/images` endpoint, specifically the the `complianceVulnerabilities` and `cveVulnerabilities` objects, to generate more thorough reports.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/stats/compliance_refresh_post.md
+++ b/api/descriptions/stats/compliance_refresh_post.md
@@ -1,6 +1,6 @@
 Refreshes the current day's list and counts of compliance issues, as well as the list of affected running resources.
 
-This endpoint returns the same response as /api/v1/stats/compliance, but with updated data for the current day.
+This endpoint returns the same response as `/api/v1/stats/compliance`, but with updated data for the current day.
 
 The following example command that uses curl and basic auth to refresh compliance statistics:
 

--- a/api/descriptions/stats/vulnerabilities_impacted_resources_get.md
+++ b/api/descriptions/stats/vulnerabilities_impacted_resources_get.md
@@ -5,7 +5,7 @@ The data in this endpoint is updated every time a scan runs.
 By default, Twistlock rescans your environment every 24 hours.
 Alternatively, you can manually update the stats by clicking the Refresh button in Vulnerability Explorer.
 
-The following example command retrieves a risk tree for CVE-2015-0313.
+The following example command retrieves a risk tree for `CVE-2015-0313`.
 
 ```bash
 $ curl -k \

--- a/api/descriptions/stats/vulnerabilities_refresh_post.md
+++ b/api/descriptions/stats/vulnerabilities_refresh_post.md
@@ -1,6 +1,6 @@
 Refreshes the current day's CVE counts and CVE list, as well as their descriptions.
 
-This endpoint returns the same response as /api/v1/stats/vulnerabilities, but with updated data for the current day.
+This endpoint returns the same response as `/api/v1/stats/vulnerabilities`, but with updated data for the current day.
 
 The following example command that uses curl and basic auth to refresh the vulnerability statistics:
 

--- a/api/descriptions/tags/name_put.md
+++ b/api/descriptions/tags/name_put.md
@@ -2,7 +2,7 @@ Updates the parameters that define a given tag.
 
 The following example curl command updates the parameters that define the tag named `my_tag`.
 In general, all parameters in your PUT request should be defined or redefined.
-Any field left unspecified is assigned the value of `""` (i.e. an emtpy string).
+Any field left unspecified is assigned the value of `""` (an empty string).
 
 ```bash
 $ curl -k \

--- a/api/descriptions/tags/post.md
+++ b/api/descriptions/tags/post.md
@@ -1,5 +1,5 @@
 Creates a new tag.
-Any field left unspecified is assigned the value of `""` (i.e. an emtpy string).
+Any field left unspecified is assigned the value of `""` (an empty string).
 
 ```bash
 $ curl -k \

--- a/api/descriptions/trust/id_delete.md
+++ b/api/descriptions/trust/id_delete.md
@@ -1,4 +1,4 @@
-Deletes an image trust group. Specify the image trust group to be deleted by the _id.
+Deletes an image trust group. Specify the image trust group to be deleted by the `_id`.
 
 The following example curl command uses basic auth to specify a image trust group for deletion with the handle `docker-ubuntu-group`.
 

--- a/api/descriptions/trust/id_put.md
+++ b/api/descriptions/trust/id_put.md
@@ -1,10 +1,10 @@
 Updates the properties of an existing trusted image entry.
 
-In the request payload, specify either the _id or image name.
+In the request payload, specify either the `_id` or image name.
 The trusted group ID needs to be specified in request payload.
 
 On success, this method returns the handle (unique ID) for the modified entry.
-For more information about handles, see the _id in the response body for the GET method.
+For more information about handles, see the `_id` in the response body for the GET method.
 
 The following example curl command uses basic auth to modify the image property for an existing trusted image entry, where the handle for the entry is `docker-ubuntu-group`.
 

--- a/api/descriptions/trust/post.md
+++ b/api/descriptions/trust/post.md
@@ -1,8 +1,8 @@
 Adds a trusted image to the system.
 Specify trusted images using either the image name or layers properties.
 
-On success, this method returns the _id for the image trust group.
-For more information about handles, see the _id key in the response body for the GET method.
+On success, this method returns the `_id` for the image trust group.
+For more information about handles, see the `_id` key in the response body for the GET method.
 
 The following example curl command uses basic auth to specify that the Ubuntu 16.04 image on Docker Hub is a trusted image.
 

--- a/api/descriptions/users/password_put.md
+++ b/api/descriptions/users/password_put.md
@@ -1,6 +1,6 @@
-Changes a user's password (i.e. the user that is invoking the API).
+Changes a user's password (the user that is invoking the API).
 
-The following example command uses curl and basic auth to reaplce user <USER>'s password with <NEWPASSWORD>:
+The following example command uses curl and basic auth to replace `<USER>` password with `<NEWPASSWORD>`:
 
 ```
 $ curl -k \

--- a/api/descriptions/vms/labels_get.md
+++ b/api/descriptions/vms/labels_get.md
@@ -1,7 +1,5 @@
 Returns an array of strings containing all AWS tags of the scanned VM images.
 
-A call to this api endpoint may resemble the following code snippet:
-
 ```bash
 $ curl -k \
   -u <USER> \


### PR DESCRIPTION
Fix spelling in API doc endpoint descriptions (in markdown files).

* Add a script that runs the spell checker.
* Add an exceptions list.