### PR TITLE
Initial doc updates for version.

### DIFF
--- a/api/descriptions/version/get.md
+++ b/api/descriptions/version/get.md
@@ -1,9 +1,15 @@
-Returns Console's version number.
+Retrieves the version number for Console.
+
+### cURL Request
+
+The following cURL command retrieves the version number for Console.
 
 ```bash
 $ curl -k \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X GET \
-  https://<CONSOLE>:8083/api/v1/version
+  https://<CONSOLE>/api/v1/version
 ```
+
+A successful response returns the version number for Console.


### PR DESCRIPTION
@iansk Note: I couldn't find any place in the UI where this endpoint is invoked. I thought it might be invoked when clicking the bell icon button at the top (which displays the version), or in one of the manage screens, but I don't see it there either. Perhaps it's just when console loads?