### PR TITLE
Initial doc changes for tas-droplets

### DIFF
--- a/api/_topic_map.yml
+++ b/api/_topic_map.yml
@@ -1169,6 +1169,17 @@
     delete: !include ../descriptions/tags/tag_cve_delete.md
 
 #
+# /api/v1/tas-droplets
+#
+/tas-droplets:
+  displayName: tas-droplets
+
+  get: !include ../descriptions/tas-droplets/get.md
+
+  /download:
+    get: !include ../descriptions/tas-droplets/download_get.md
+
+#
 # /api/v1/trust
 #
 /trust:

--- a/api/descriptions/tas-droplets/download_get.md
+++ b/api/descriptions/tas-droplets/download_get.md
@@ -1,0 +1,18 @@
+Downloads all Tanzu Application Service (TAS) droplets.
+
+This endpoint maps to the CSV hyperlink in **Monitor > Vulnerabilities > VMware Tanzu blobstore** in the Console UI.
+
+### cURL Request
+
+The following cURL command downloads all TAS droplets to a CSV file called `tas_droplets.csv`:
+
+```bash
+curl -k \
+  -u <USER> \
+  -H 'Content-Type: application/json' \
+  -X GET \
+  https://<CONSOLE>/api/v1/tas-droplets/download \
+  > tas_droplets.csv
+```
+
+A successful response displays the status of the download.

--- a/api/descriptions/tas-droplets/download_get.md
+++ b/api/descriptions/tas-droplets/download_get.md
@@ -1,4 +1,4 @@
-Downloads all Tanzu Application Service (TAS) droplets.
+Downloads scan reports for Tanzu Application Service (TAS) droplets in CSV format.
 
 This endpoint maps to the CSV hyperlink in **Monitor > Vulnerabilities > VMware Tanzu blobstore** in the Console UI.
 

--- a/api/descriptions/tas-droplets/get.md
+++ b/api/descriptions/tas-droplets/get.md
@@ -1,4 +1,4 @@
-Retrieves all Tanzu Application Service (TAS) droplets.
+Retrieves scan reports for Tanzu Application Service (TAS) droplets.
 
 This endpoint maps to the table in **Monitor > Vulnerabilities > VMware Tanzu blobstore** in the Console UI.
 

--- a/api/descriptions/tas-droplets/get.md
+++ b/api/descriptions/tas-droplets/get.md
@@ -1,0 +1,17 @@
+Retrieves all Tanzu Application Service (TAS) droplets.
+
+This endpoint maps to the table in **Monitor > Vulnerabilities > VMware Tanzu blobstore** in the Console UI.
+
+### cURL Request
+
+The following cURL command retrieves all TAS droplets.
+
+```bash
+$ curl -k \
+  -u <USER> \
+  -H 'Content-Type: application/json' \
+  -X GET \
+  https://<CONSOLE>/api/v1/tas-droplets \
+```
+
+A successful response returns all TAS droplets.


### PR DESCRIPTION
@iansk FYI, an odd thing is happening with the doc build for tas-droplets. Even without the changes, there are a number of tas-droplet endpoints showing up in the docs even though they are not in the _topic_map.yml. They're not in the suppress file either.

You'll see in that yml file, the added a /api/v1/tas-droplets section with endpoints for get /tas-droplets and get /tas-droplets/download, both of which appear with the other tas-droplets endpoints.

Not sure if this an issue but thought I'd let you know.