### PR TITLE
Update release-notes-21-04.adoc

### DIFF
--- a/rn/release-information/release-notes-21-04.adoc
+++ b/rn/release-information/release-notes-21-04.adoc
@@ -251,6 +251,9 @@ As a reminder, the Access User role was originally designed for users to install
 // #19679
 * As part of the work to introduce the new ATT&CK dashboard, all audits will be discarded on upgrade.
 
+// #23839
+* Installations using legacy host based licensing will not have the WAAS feature available
+
 
 === Breaking changes in the API
 


### PR DESCRIPTION
Adding the following note to "Breaking changes" section:

"Installations using legacy host based licensing will not have the WAAS feature available"