### PR TITLE
Fix error in twistcli support

### DIFF
--- a/admin_guide/tools/twistcli.adoc
+++ b/admin_guide/tools/twistcli.adoc
@@ -303,8 +303,8 @@ The following table highlights the available support:
 |No
 
 |`install`
-|No
 |Yes {set:cellbgcolor:#D0FAEE}
+|Yes
 |Yes
 |Yes
 |No {set:cellbgcolor:#fff}
@@ -323,7 +323,6 @@ The following table highlights the available support:
 ^1^
 Stand-alone refers to installing an instance of Console or Defender onto a single host that isn't part of a cluster.
 For stand-alone installations of Console, use the _twistlock.sh_ script to install Onebox.
-For stand-alone installations of Defender, log into Console, go to *Manage > Defenders > Deploy*, and generate an install command.
 
 The _twistcli console install_ command for Kubernetes and OpenShift combines two steps into a single command to simplify how Console is deployed.
 This command internally generates a YAML configuration file and then creates Console's resources with _kubectl create_ in a single shot.


### PR DESCRIPTION
Starting in 21.04, we support installation of stand-alone container and host Defenders.