### PR TITLE
Update user_cert_validity_period.adoc

### DIFF
--- a/admin_guide/configure/user_cert_validity_period.adoc
+++ b/admin_guide/configure/user_cert_validity_period.adoc
@@ -45,7 +45,7 @@ This step generates fresh certificates.
 * If you integrated with SAML, log in with your SAML credentials.
 * If you are using Prisma Cloud users, log in with your Prisma Cloud user credentials.
 
-. On the left menu, click *Manage > Authentication > User certificate*.
+. On the left menu, click *Manage > Authentication > User certificates*.
 
 . Copy the installation script, and run it on your local machine.
 +

--- a/admin_guide/configure/user_cert_validity_period.adoc
+++ b/admin_guide/configure/user_cert_validity_period.adoc
@@ -45,8 +45,7 @@ This step generates fresh certificates.
 * If you integrated with SAML, log in with your SAML credentials.
 * If you are using Prisma Cloud users, log in with your Prisma Cloud user credentials.
 
-. On the left menu, click *Manage > Authentication > Credentials*.
-Non-admin users are taken directly to this page.
+. On the left menu, click *Manage > Authentication > User certificate*.
 
 . Copy the installation script, and run it on your local machine.
 +


### PR DESCRIPTION
Navigated to the wrong page:
from On the left menu, click Manage > Authentication > Credentials to On the left menu, click *Manage > Authentication > Client certificate*.

Removed "Non-admin users are taken directly to this page." since we changed this page's permissions as part of the custom roles.

@iansk 
@grevach FYI