### PR TITLE
updated with note for defender manager role

### DIFF
--- a/rn/release-information/release-notes-21-04.adoc
+++ b/rn/release-information/release-notes-21-04.adoc
@@ -251,6 +251,9 @@ Access Users will no longer be able to login to the Console UI.
 This role will be removed in the next release.
 As a reminder, the Access User role was originally designed for users to install certificates as part of a mechanism to control access to Docker commands.
 
+// #17804
+* Defender Manager user role (Mapped to "Cloud Provisioning Admin" permission group on SaaS) will no longer be able to perform CI scans. 
+
 // #19679
 * As part of the work to introduce the new ATT&CK dashboard, all audits will be discarded on upgrade.
 


### PR DESCRIPTION
Defender manager role won't be able to perform CI scans.