### PR TITLE
Fix serverless compliance not by defender

### DIFF
--- a/admin_guide/compliance/serverless.adoc
+++ b/admin_guide/compliance/serverless.adoc
@@ -130,8 +130,7 @@ Detects functions with permissions to unused APIs that allow privilege elevation
 === Scanning serverless functions
 
 Configure Prisma Cloud to periodically scan your serverless functions.
-Function scanning is handled by Defender.
-Console dynamically selects an available Defender to execute the scan job.
+Function scanning is handled by the Console.
 
 [.procedure]
 . Open Console.

--- a/admin_guide/compliance/serverless.adoc
+++ b/admin_guide/compliance/serverless.adoc
@@ -130,7 +130,7 @@ Detects functions with permissions to unused APIs that allow privilege elevation
 === Scanning serverless functions
 
 Configure Prisma Cloud to periodically scan your serverless functions.
-Function scanning is handled by the Console.
+Function scanning is handled by Console.
 
 [.procedure]
 . Open Console.


### PR DESCRIPTION
Fixed wrong statement that the defender handles the serverless compliance scan