### PR TITLE
Update console.adoc

### DIFF
--- a/ref_arch/platform_components/console.adoc
+++ b/ref_arch/platform_components/console.adoc
@@ -45,5 +45,4 @@ When using Prisma Cloud Compute, the graphical interface is accessable directly 
 
 The Prisma Cloud API is REST-based and can be accessed over HTTP or HTTPS
 on ports 8081 and 8083 respectively. For more information about the
-Prisma Cloud API, see the support article
-https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin-guide-compute/api/api_reference.html[here].
+Prisma Cloud API, see https://prisma.pan.dev/api/cloud/cwpp/ [this] article.

--- a/ref_arch/platform_components/console.adoc
+++ b/ref_arch/platform_components/console.adoc
@@ -45,4 +45,4 @@ When using Prisma Cloud Compute, the graphical interface is accessable directly 
 
 The Prisma Cloud API is REST-based and can be accessed over HTTP or HTTPS
 on ports 8081 and 8083 respectively. For more information about the
-Prisma Cloud API, see https://prisma.pan.dev/api/cloud/cwpp/ [this] article.
+Prisma Cloud API, see https://prisma.pan.dev/api/cloud/cwpp/[this] article.


### PR DESCRIPTION
replaced the broken link to https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin-compute
with https://prisma.pan.dev/api/cloud/cwpp/