### PR TITLE
Update 21.04 release notes

### DIFF
--- a/rn/release-information/release-notes-21-04.adoc
+++ b/rn/release-information/release-notes-21-04.adoc
@@ -295,6 +295,10 @@ If listener type is set to *TCP Socket*, Defender acts as a Docker proxy.
 // #23566
 * Compliance check 420, _Image is not updated to latest_, has been deprecated and removed from the product.
 
+// #25866
+* As part of the work to improve runtime support for App-Embedded Defenders, explicitly denied lists in App-Embedded runtime rules have been deprecated.
+By default, everything is denied unless explicitly allow-listed.
+
 
 === Upcoming deprecations
 


### PR DESCRIPTION
Add a bullet to list of deprecated features. App-Embedded runtime rules no longer have deny-lists.