### PR TITLE
Added best practices for registries on a large scale

### DIFF
--- a/admin_guide/vulnerability_management/registry_scanning.adoc
+++ b/admin_guide/vulnerability_management/registry_scanning.adoc
@@ -26,67 +26,10 @@ In general, you should configure Prisma Cloud with a large scope of defenders, b
 At scan-time, Prisma Cloud enumerates the available Defenders according to your scope, manages the resource pool, and handles issues such as restarting partially completed jobs. 
 If you explicitly select one or two defenders to handle scanning, the hosts where these Defenders run are a single point of failure. If the host fails, or gets destroyed, you have to reconfigure your scan settings with different Defenders.
 
-For large registries or aggressive scan intervals, increase the number of Defenders in the scope to improve throughtput and reduce scan time.
-
 Registry scanning is scoped by OS type.
 Windows Defenders can only scan Windows images, and Linux Defenders can only scan Linux images.
 
-If you remove an image from the registry, or the registry becomes unavailable, Prisma Cloud maintains the scan results according to your setup under *Manage > System > Scan > Registry scan results*.
-After the specified number of days, the scan results are purged.
-
-=== Large-scale registries
-
-When you have very large registries, you must optimize your scan configuration to maximize throughput and minimize scan time.
-The first obvious optimization is to increase the number of scanners in the scope.
-The second optimization is to specify a version matching pattern in your registry scan configuration.
-
-NOTE: Optimizing registry scans with version pattern matching is only necessary for very large registries with tens of thousands of repositories and millions of images.
-
-The scanner makes many API calls to the registry to retrieve metadata for the registry, repos, and images.
-All metadata must be collected, collated, and sorted before scanning can start.
-Consider the normal flow for collecting metadata:
-
-[source]
-----
-Get a list of all repos in the registry
-For each repo:
-  Get a list of all image tags
-  For each image tag:
-    Get the image manifest (which contains the last modified date)
-
-Sort, Cap, Scan
-----
-
-After fetching all metadata, the scanner sorts the images by last modified date, and caps the list if a cap value is specified in the scan configuration.
-The default cap value is 5.
-With a cap of 5, the scanner fetches the five most recently modified images from each repository in the registry for scanning.
-
-If you specify a version matching pattern, the scanner looks to the image tag for sort order.
-Without a version matching pattern, the sort order is last modified date.
-With a version matching pattern, you customize how the scanner interprets image tags for sorting.
-For example, if you utilize semantic versioning in your image names, you could specify the following version pattern:
-
-  *-%d.%d.%d
-
-The scanner parses each image tag, extracts the pattern from the tag, and splits it into its constituent parts.
-After all tags are parsed, they are sorted, and capped according to your configuration.
-The optimized flow for collecting metadata eliminates the inner loop, substantially reducing the number of requests to the registry so scanning can start sooner.
-
-[source]
-----
-Get a list of all repos in the registry
-For each repo:
-  Get a list of all images tags
-
-Sort, Cap, Scan
-----
-
-If your repo had three images, and your scan configuration specified a cap of `2` and version pattern of `*-%d.%d.%d`, you'd get the following result:
-
-  myimage-3.0.0 <<<--- Scan
-  myimage-2.0.1 <<<--- Scan
-  myimage-2.0.0 (Not scanned)
-
+If you remove an image from the registry, or the registry becomes unavailable, Prisma Cloud maintains the scan results according to your setup under *Manage > System > Scan > Registry scan results*. After the specified number of days, the scan results are purged.
 
 === Registry scan settings
 
@@ -219,7 +162,6 @@ If the version matching pattern is left unspecified, Prisma Cloud orders images 
 
 |===
 
-
 [.task, #_registry_scan_settings]
 === Configure Prisma Cloud to scan a registry
 
@@ -234,6 +176,76 @@ To scan images in a registry, create a new registry scan rule.
 
 . Click *Add registry settings*.
 
+=== Registries on a large scale
+
+When you have very large registries, or a large amount of regitries, you must optimize your scan configuration to maximize throughput and minimize scan time.
+Follow the instructions below to improve your registry scanning process:
+
+1. For large registries or aggressive scan intervals, *increase the number of scanners in the scope*.
++
+The number of scanning defenders should increase with regard to the registry size. As the number of images in the registry increases, so does the number of defenders scanning this registry.
+
+2. Use the *deafult cap* value (Cap = 5) in your registry scan configuration. 
++
+The scanner makes many API calls to the registry to retrieve metadata for the registry, repos, and images.
+All metadata must be collected, collated, and sorted before scanning can start.
+Consider the normal flow for collecting metadata:
++
+[source]
+----
+Get a list of all repos in the registry
+For each repo:
+  Get a list of all image tags
+  For each image tag:
+    Get the image manifest (which contains the last modified date)
+
+Sort, Cap, Scan
+----
++
+After fetching all metadata, the scanner sorts the images by last modified date, and caps the list if a cap value is specified in the scan configuration.
+The default cap value is 5. With a cap of 5, the scanner fetches the five most recently modified images from each repository in the registry for scanning.
++
+When setting a large number as cap, or setting the cap to 0 (to scan all images in a repository), the registry scan will be longer.
+
+3. Use *version matching pattern* in your registry scan configuration.
++
+NOTE: Optimizing registry scans with version pattern matching is only necessary for very large registries with tens of thousands of repositories and millions of images.
++
+Further to the described in the previous section for cap, if you specify a version matching pattern, the scanner looks to the image tag for sort order.
+Without a version matching pattern, the sort order is last modified date.
+With a version matching pattern, you customize how the scanner interprets image tags for sorting.
+For example, if you utilize semantic versioning in your image names, you could specify the following version pattern:
+
+  *-%d.%d.%d
++
+The scanner parses each image tag, extracts the pattern from the tag, and splits it into its constituent parts.
+After all tags are parsed, they are sorted, and capped according to your configuration.
+The optimized flow for collecting metadata eliminates the inner loop, substantially reducing the number of requests to the registry so scanning can start sooner.
++
+[source]
+----
+Get a list of all repos in the registry
+For each repo:
+  Get a list of all images tags
+
+Sort, Cap, Scan
+----
++
+If your repo had three images, and your scan configuration specified a cap of `2` and version pattern of `*-%d.%d.%d`, you'd get the following result:
+
+  myimage-3.0.0 <<<--- Scan
+  myimage-2.0.1 <<<--- Scan
+  myimage-2.0.0 (Not scanned)
+
+4. The same scanning defenders collection can not be used for scanning all registries.
++
+It is preferred that each scanning defenders collection will be mutually exclusive with a single registry. If a 1:1 ratio is not feasible, have as many defenders groups possible, so each group scans several different registries. 
++
+This is required to avoid a scenario where a single IP (a single defender) performs too many queries to the registry provider API to discover repos/tags, which might cause this defender to get throttled. 
+
+5. Follow the xref:../install/system_requirements.adoc#hardware[system hardware requirements] for defenders providing registry scanning.
+
+6. Locate the scanning defenders in the same region as the registry.
 
 === Additional scan settings
 
@@ -241,7 +253,6 @@ Additional scan settings can be found under *Manage > System > Scan*, where you 
 
 NOTE: The *Manage > System > Scan* page has an option called *Only scan images with running containers*.
 This option does NOT apply to registry scanning; all images targeted by your registry scanning rule will be scanned regardless of how *Only scan images with running containers* is set.
-
 
 === CRI/containerd-only environments
 

--- a/admin_guide/vulnerability_management/registry_scanning.adoc
+++ b/admin_guide/vulnerability_management/registry_scanning.adoc
@@ -203,19 +203,20 @@ Sort, Cap, Scan
 ----
 +
 After fetching all metadata, the scanner sorts the images by last modified date, and caps the list if a cap value is specified in the scan configuration.
-The default cap value is 5. With a cap of 5, the scanner fetches the five most recently modified images from each repository in the registry for scanning.
+The default cap value is 5.
+With a cap of 5, the scanner fetches the five most recently modified images from each repository in the registry for scanning.
 +
-When setting a large number as cap, or setting the cap to 0 (to scan all images in a repository), the registry scan will be longer.
+When setting a large number for cap, or setting cap to 0 (to scan all images in a repository), the registry scan will be longer.
 
 3. Use *version matching pattern* in your registry scan configuration.
 +
 NOTE: Optimizing registry scans with version pattern matching is only necessary for very large registries with tens of thousands of repositories and millions of images.
 +
-Further to the described in the previous section for cap, if you specify a version matching pattern, the scanner looks to the image tag for sort order.
+Further to the previous section on cap, if you specify a version matching pattern, the scanner looks to the image tag for sort order.
 Without a version matching pattern, the sort order is last modified date.
 With a version matching pattern, you customize how the scanner interprets image tags for sorting.
 For example, if you utilize semantic versioning in your image names, you could specify the following version pattern:
-
++
   *-%d.%d.%d
 +
 The scanner parses each image tag, extracts the pattern from the tag, and splits it into its constituent parts.
@@ -232,20 +233,22 @@ Sort, Cap, Scan
 ----
 +
 If your repo had three images, and your scan configuration specified a cap of `2` and version pattern of `*-%d.%d.%d`, you'd get the following result:
-
++
   myimage-3.0.0 <<<--- Scan
   myimage-2.0.1 <<<--- Scan
   myimage-2.0.0 (Not scanned)
 
 4. The same scanning defenders collection can not be used for scanning all registries.
 +
-It is preferred that each scanning defenders collection will be mutually exclusive with a single registry. If a 1:1 ratio is not feasible, have as many defenders groups possible, so each group scans several different registries. 
+It is preferred that each scanning defenders collection will be mutually exclusive with a single registry.
+If a 1:1 ratio is not feasible, have as many defenders groups possible, so each group scans several different registries. 
 +
 This is required to avoid a scenario where a single IP (a single defender) performs too many queries to the registry provider API to discover repos/tags, which might cause this defender to get throttled. 
 
-5. Follow the xref:../install/system_requirements.adoc#hardware[system hardware requirements] for defenders providing registry scanning.
+5. Follow the xref:../install/system_requirements.adoc#hardware[hardware requirements] for Defenders that perform registry scanning.
 
-6. Locate the scanning defenders in the same region as the registry.
+6. Locate the scanning Defenders in the same region as the registry.
+
 
 === Additional scan settings
 

--- a/admin_guide/vulnerability_management/registry_scanning.adoc
+++ b/admin_guide/vulnerability_management/registry_scanning.adoc
@@ -238,12 +238,13 @@ If your repo had three images, and your scan configuration specified a cap of `2
   myimage-2.0.1 <<<--- Scan
   myimage-2.0.0 (Not scanned)
 
-4. The same scanning defenders collection can not be used for scanning all registries.
+4. Create a dedicated Defender collection for each registry.
 +
-It is preferred that each scanning defenders collection will be mutually exclusive with a single registry.
-If a 1:1 ratio is not feasible, have as many defenders groups possible, so each group scans several different registries. 
+Each registry should have a dedicated Defenders that perform the scanning.
+Don't reuse the same Defender collection for all registries.
+If a 1:1 ratio of Defender collections to registries isn't feasible, create as many collections as possible to split the load. 
 +
-This is required to avoid a scenario where a single IP (a single defender) performs too many queries to the registry provider API to discover repos/tags, which might cause this defender to get throttled. 
+This setup prevents a scenario where a single IP (a single Defender) performs too many queries to the registry provider API for repo/tag discovery, which might cause the Defender to be throttled. 
 
 5. Follow the xref:../install/system_requirements.adoc#hardware[hardware requirements] for Defenders that perform registry scanning.
 


### PR DESCRIPTION
Following an issue brought up by customer Home Depot, extended the section of registries on a large scale, to include best practices for cases of large registries, and a large number of registries