### PR TITLE
remove CNCF conformant statement

### DIFF
--- a/admin_guide/install/system_requirements.adoc
+++ b/admin_guide/install/system_requirements.adoc
@@ -240,8 +240,6 @@ GKE 1.18.16 (Docker and containerd 1.4.3)
 
 GKE 1.17.17 (Docker)
 
-Includes managed solutions that are https://www.cncf.io/certification/software-conformance/[CNCF Certified Kubernetes conformant].
-
 |OpenShift
 |3.11 (Docker version only), 4.5, 4.6, 4.7
 


### PR DESCRIPTION
Statement on also supporting CNCF conformant managed k8s services was creating confusion - only explicitly tested platforms listed in this doc are supported