### PR TITLE
Clarify interval for dispatching vulnerability alerts

### DIFF
--- a/admin_guide/alerts/alert_mechanism.adoc
+++ b/admin_guide/alerts/alert_mechanism.adoc
@@ -41,12 +41,10 @@ The limit is designed to contain Console resource consumption in large environme
 
 The number of known vulnerabilities in a resource is not static over time.
 As the Prisma Cloud Intelligence Stream is updated with new data, new vulnerabilities might be uncovered in resources that were previously considered clean.
-The first time a resource (image, container, host, etc) enters the environment, Prisma Cloud assesses it for vulnerabilities.
-If a vulnerability violates a rule in the policy, and the rule has been configured to trigger an alert, an alert is dispatched.
-Thereafter, every resource is periodically rescanned.
-Additional alerts are dispatched only when new vulnerabilities that match your alert profile settings are detected.
-With vulnerability alerts, you get one, and only one, alert for each vulnerability detected (aggregated by scan).
+The first time a resource (image, container, host, etc) enters the environment, Prisma Cloud assesses it for vulnerabilities. Thereafter, every resource is periodically rescanned.
 
+New vulnerabilities detected for new and existing resources are aggregated, and dispatched as alerts every 24 hours according to your alert profile settings.
+With vulnerability alerts, you get one, and only one, alert for each vulnerability detected (aggregated by scan).
 
 ==== Compliance alerts
 

--- a/admin_guide/alerts/alert_mechanism.adoc
+++ b/admin_guide/alerts/alert_mechanism.adoc
@@ -41,10 +41,12 @@ The limit is designed to contain Console resource consumption in large environme
 
 The number of known vulnerabilities in a resource is not static over time.
 As the Prisma Cloud Intelligence Stream is updated with new data, new vulnerabilities might be uncovered in resources that were previously considered clean.
-The first time a resource (image, container, host, etc) enters the environment, Prisma Cloud assesses it for vulnerabilities. Thereafter, every resource is periodically rescanned.
+The first time a resource (image, container, host, etc) enters the environment, Prisma Cloud assesses it for vulnerabilities.
+Thereafter, every resource is periodically rescanned.
 
-New vulnerabilities detected for new and existing resources are aggregated, and dispatched as alerts every 24 hours according to your alert profile settings.
+New vulnerabilities detected for new and existing resources are aggregated, and dispatched as alerts every 24 hours according to the settings in your alert profiles.
 With vulnerability alerts, you get one, and only one, alert for each vulnerability detected (aggregated by scan).
+
 
 ==== Compliance alerts
 


### PR DESCRIPTION
The vuln alerts are aggregated and sent only every 24 hours (they are not sent immediately for new resources)