### PR TITLE
Updated  Kubernetes webhook templates

### DIFF
--- a/admin_guide/access_control/open_policy_agent.adoc
+++ b/admin_guide/access_control/open_policy_agent.adoc
@@ -109,6 +109,8 @@ Must specify one of v1, v1beta1 as an array
 
 When creating your ValidatingWebhookConfiguration object, use the right template.
 
+Replace the "clientConfig:" stanza with your "Advanced Defender Settings" configuration. 
+
 *Kubernetes v1.13 to v1.15:*
 
 [source]
@@ -127,7 +129,7 @@ webhooks:
       - operations: ["CREATE", "UPDATE", "CONNECT"]
         apiGroups: ["*"]
         apiVersions: ["*"]
-        resources: ["*"]
+        resources: ["*/*"]
     clientConfig:
       caBundle: "TW-CA-BUNDLE"
       service:
@@ -156,7 +158,7 @@ webhooks:
       - operations: ["CREATE", "UPDATE", "CONNECT"]
         apiGroups: ["*"]
         apiVersions: ["*"]
-        resources: ["*"]
+        resources: ["*/*"]
     clientConfig:
       caBundle: "TW-CA-BUNDLE"
       service:


### PR DESCRIPTION
* updated ClientConfig instructions for webhook templates specifying to copy in "clientConfig:" from user tenant
* Kubernetes v1.13-.1.15 and Kubernetes v1.16 or later template updates: updated resource fields for both templates to reflect from "/" to "*/*"